### PR TITLE
Support extra constraint input (geomeTRIC constraints.txt format)

### DIFF
--- a/torsiondrive/dihedral_scanner.py
+++ b/torsiondrive/dihedral_scanner.py
@@ -38,7 +38,7 @@ class DihedralScanner:
     DihedralScanner class is designed to create a dihedral grid, and fill in optimized geometries and energies
     into the grid, by running wavefront propagations of constrained optimizations
     """
-    def __init__(self, engine, dihedrals, grid_spacing, energy_decrease_thresh = 0.00001, init_coords_M=None, verbose=False):
+    def __init__(self, engine, dihedrals, grid_spacing, init_coords_M=None, verbose=False):
         """
         inputs:
         -------
@@ -81,7 +81,7 @@ class DihedralScanner:
         # filename for storing finished task result
         self.task_result_fname = 'dihedral_scanner_task_result.p'
         # threshold for determining the energy decrease
-        self.energy_decrease_thresh = energy_decrease_thresh
+        self.energy_decrease_thresh = 0.00001
 
     #----------------------
     # Initializing methods

--- a/torsiondrive/dihedral_scanner.py
+++ b/torsiondrive/dihedral_scanner.py
@@ -38,7 +38,7 @@ class DihedralScanner:
     DihedralScanner class is designed to create a dihedral grid, and fill in optimized geometries and energies
     into the grid, by running wavefront propagations of constrained optimizations
     """
-    def __init__(self, engine, dihedrals, grid_spacing, init_coords_M=None, verbose=False):
+    def __init__(self, engine, dihedrals, grid_spacing, energy_decrease_thresh = 0.00001, init_coords_M=None, verbose=False):
         """
         inputs:
         -------
@@ -81,7 +81,7 @@ class DihedralScanner:
         # filename for storing finished task result
         self.task_result_fname = 'dihedral_scanner_task_result.p'
         # threshold for determining the energy decrease
-        self.energy_decrease_thresh = 0.00001
+        self.energy_decrease_thresh = energy_decrease_thresh
 
     #----------------------
     # Initializing methods

--- a/torsiondrive/launch.py
+++ b/torsiondrive/launch.py
@@ -75,7 +75,6 @@ def main():
     parser.add_argument('-e', '--engine', type=str, default="psi4", choices=['qchem', 'psi4', 'terachem'], help='Engine for running scan')
     parser.add_argument('-c', '--constraints', type=str, default=None, help='Provide a constraints file in geomeTRIC format for additional freeze or set constraints (geomeTRIC or TeraChem only)')
     parser.add_argument('--native_opt', action='store_true', default=False, help='Use QM program native constrained optimization algorithm. This will turn off geomeTRIC package.')
-    parser.add_argument('--energy_thresh', type=float, default=0.0001, help='Only activate grid points if the new optimization is <thre> lower than the previous lowest energy (in a.u.).')
     parser.add_argument('--wq_port', type=int, default=None, help='Specify port number to use Work Queue to distribute optimization jobs.')
     parser.add_argument('--zero_based_numbering', action='store_true', help='Use zero_based_numbering in dihedrals file.')
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Print more information while running.')
@@ -110,9 +109,7 @@ def main():
     init_coords_M = Molecule(args.init_coords) if args.init_coords else None
 
     # create DihedralScanner object
-    scanner = DihedralScanner(engine, dihedrals=dihedral_idxs, grid_spacing=grid_spacing,
-                              energy_decrease_thresh = args.energy_thresh,
-                              init_coords_M=init_coords_M, verbose=args.verbose)
+    scanner = DihedralScanner(engine, dihedrals=dihedral_idxs, grid_spacing=grid_spacing, init_coords_M=init_coords_M, verbose=args.verbose)
     # Run the scan!
     scanner.master()
     # After finish, print result

--- a/torsiondrive/launch.py
+++ b/torsiondrive/launch.py
@@ -75,6 +75,7 @@ def main():
     parser.add_argument('-e', '--engine', type=str, default="psi4", choices=['qchem', 'psi4', 'terachem'], help='Engine for running scan')
     parser.add_argument('-c', '--constraints', type=str, default=None, help='Provide a constraints file in geomeTRIC format for additional freeze or set constraints (geomeTRIC or TeraChem only)')
     parser.add_argument('--native_opt', action='store_true', default=False, help='Use QM program native constrained optimization algorithm. This will turn off geomeTRIC package.')
+    parser.add_argument('--energy_thresh', type=float, default=0.0001, help='Only activate grid points if the new optimization is <thre> lower than the previous lowest energy (in a.u.).')
     parser.add_argument('--wq_port', type=int, default=None, help='Specify port number to use Work Queue to distribute optimization jobs.')
     parser.add_argument('--zero_based_numbering', action='store_true', help='Use zero_based_numbering in dihedrals file.')
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Print more information while running.')
@@ -109,7 +110,9 @@ def main():
     init_coords_M = Molecule(args.init_coords) if args.init_coords else None
 
     # create DihedralScanner object
-    scanner = DihedralScanner(engine, dihedrals=dihedral_idxs, grid_spacing=grid_spacing, init_coords_M=init_coords_M, verbose=args.verbose)
+    scanner = DihedralScanner(engine, dihedrals=dihedral_idxs, grid_spacing=grid_spacing,
+                              energy_decrease_thresh = args.energy_thresh,
+                              init_coords_M=init_coords_M, verbose=args.verbose)
     # Run the scan!
     scanner.master()
     # After finish, print result

--- a/torsiondrive/launch.py
+++ b/torsiondrive/launch.py
@@ -4,9 +4,8 @@
 from __future__ import print_function
 
 from torsiondrive.dihedral_scanner import DihedralScanner
-from torsiondrive.qm_engine import EnginePsi4, EngineQChem, EngineTerachem
+from torsiondrive.qm_engine import EnginePsi4, EngineQChem, EngineTerachem, make_constraints_dict
 from geometric.molecule import Molecule
-
 
 def load_dihedralfile(dihedralfile, zero_based_numbering=False):
     """
@@ -51,7 +50,7 @@ def load_dihedralfile(dihedralfile, zero_based_numbering=False):
                 dihedral_idxs.append([int(i) for i in line.split()])
     return dihedral_idxs
 
-def create_engine(enginename, inputfile=None, work_queue_port=None, native_opt=False):
+def create_engine(enginename, inputfile=None, work_queue_port=None, native_opt=False, extra_constraints=None):
     """
     Function to create a QM Engine object with work_queue and geomeTRIC setup.
     This is intentionally left outside of DihedralScanner class, because multiple DihedralScanner could share the same engine
@@ -63,7 +62,7 @@ def create_engine(enginename, inputfile=None, work_queue_port=None, native_opt=F
         work_queue = WorkQueue(work_queue_port)
     else:
         work_queue = None
-    engine = engine_dict[enginename](inputfile, work_queue, native_opt=native_opt)
+    engine = engine_dict[enginename](inputfile, work_queue, native_opt=native_opt, extra_constraints=extra_constraints)
     return engine
 
 def main():
@@ -74,6 +73,7 @@ def main():
     parser.add_argument('--init_coords', type=str, help='File contain a list of geometries, that will be used as multiple starting points, overwriting the geometry in input file.')
     parser.add_argument('-g', '--grid_spacing', type=int, nargs='*', default=[15], help='Grid spacing for dihedral scan, i.e. every 15 degrees, multiple values will be mapped to each dihedral angle')
     parser.add_argument('-e', '--engine', type=str, default="psi4", choices=['qchem', 'psi4', 'terachem'], help='Engine for running scan')
+    parser.add_argument('-c', '--constraints', type=str, default=None, help='Provide a constraints file in geomeTRIC format for additional freeze or set constraints (geomeTRIC or TeraChem only)')
     parser.add_argument('--native_opt', action='store_true', default=False, help='Use QM program native constrained optimization algorithm. This will turn off geomeTRIC package.')
     parser.add_argument('--wq_port', type=int, default=None, help='Specify port number to use Work Queue to distribute optimization jobs.')
     parser.add_argument('--zero_based_numbering', action='store_true', help='Use zero_based_numbering in dihedrals file.')
@@ -87,6 +87,12 @@ def main():
     dihedral_idxs = load_dihedralfile(args.dihedralfile, args.zero_based_numbering)
     grid_dim = len(dihedral_idxs)
 
+    # parse additional constraints
+    if args.constraints is not None:
+        constraints_dict = make_constraints_dict(open(args.constraints).read())
+    else:
+        constraints_dict = None
+
     # format grid spacing
     n_grid_spacing = len(args.grid_spacing)
     if n_grid_spacing == grid_dim:
@@ -97,7 +103,7 @@ def main():
         raise ValueError("Number of grid_spacing values %d is not consistent with number of dihedral angles %d" % (grid_dim, n_grid_spacing))
 
     # create QM Engine, and WorkQueue object if provided port
-    engine = create_engine(args.engine, inputfile=args.inputfile, work_queue_port=args.wq_port, native_opt=args.native_opt)
+    engine = create_engine(args.engine, inputfile=args.inputfile, work_queue_port=args.wq_port, native_opt=args.native_opt, extra_constraints=constraints_dict)
 
     # load init_coords if provided
     init_coords_M = Molecule(args.init_coords) if args.init_coords else None

--- a/torsiondrive/launch.py
+++ b/torsiondrive/launch.py
@@ -89,7 +89,7 @@ def main():
 
     # parse additional constraints
     if args.constraints is not None:
-        constraints_dict = make_constraints_dict(open(args.constraints).read())
+        constraints_dict = make_constraints_dict(open(args.constraints).read(), exclude=dihedral_idxs)
     else:
         constraints_dict = None
 

--- a/torsiondrive/qm_engine.py
+++ b/torsiondrive/qm_engine.py
@@ -80,6 +80,7 @@ class QMEngine(object):
                     # geomeTRIC use atomic index starting from 1
                     outfile.write("dihedral %d %d %d %d %f\n" % (d1+1, d2+1, d3+1, d4+1, v))
         else:
+            constraints_string = ''
             for key, value_list in self.extra_constraints.items():
                 if key == 'freeze' and len(value_list) > 0:
                     constraints_string += '$' + key + '\n'

--- a/torsiondrive/qm_engine.py
+++ b/torsiondrive/qm_engine.py
@@ -2,8 +2,9 @@ import os
 import subprocess
 
 import numpy as np
+from collections import OrderedDict
 from geometric.molecule import Molecule
-
+from copy import deepcopy
 
 def check_all_float(iterable):
     try:
@@ -12,12 +13,42 @@ def check_all_float(iterable):
     except ValueError:
         return False
 
+def make_constraints_dict(constraints_string):
+    """ Create an ordered dictionary with constraints specification. """  
+    constraints_mode = None
+    constraints_dict = OrderedDict([('freeze', []),('set', [])])
+    for line in constraints_string.split('\n'):
+        # Ignore anything after a comment
+        line = line.split('#')[0].lower().strip()
+        if len(line) == 0: continue
+        if line.startswith('$'):
+            if line == '$freeze':
+                constraints_mode = 'freeze'
+            elif line == '$set':
+                constraints_mode = 'set'
+            elif line == '$end':
+                constraints_mode = None
+            elif line == '$scan':
+                raise RuntimeError('Additional $scan constraints are not allowed')
+            else:
+                raise RuntimeError('Unrecognized token starting with $')
+        else:
+            if constraints_mode == None:
+                print('ERROR: ', line)
+                raise RuntimeError('Trying to read the above constraint line, but constraint mode is not set')
+            else:
+                spec_tuple = tuple(line.split())
+                if spec_tuple[0] not in ['bond','angle','dihedral']:
+                    raise RuntimeError('Only bond, angle, and dihedral constraints are supported')
+                constraints_dict[constraints_mode].append(spec_tuple)
+    return constraints_dict
 
 class QMEngine(object):
-    def __init__(self, input_file=None, work_queue=None, native_opt=False):
+    def __init__(self, input_file=None, work_queue=None, native_opt=False, extra_constraints=None):
         self.temp_type = None # will be set to either "gradient" or "optimize" later
         self.work_queue = work_queue
         self.native_opt = native_opt
+        self.extra_constraints = extra_constraints
         self.rootpath = os.getcwd()
         if input_file is not None:
             self.load_input(input_file)
@@ -42,11 +73,28 @@ class QMEngine(object):
 
     def write_constraints_txt(self):
         """ write a constraints.txt file for geomeTRIC """
-        with open('constraints.txt', 'w') as outfile:
-            outfile.write("$set\n")
-            for d1, d2, d3, d4, v in self.dihedral_idx_values:
-                # geomeTRIC use atomic index starting from 1
-                outfile.write("dihedral %d %d %d %d %f\n" % (d1+1, d2+1, d3+1, d4+1, v))
+        if self.extra_constraints is None:
+            with open('constraints.txt', 'w') as outfile:
+                outfile.write("$set\n")
+                for d1, d2, d3, d4, v in self.dihedral_idx_values:
+                    # geomeTRIC use atomic index starting from 1
+                    outfile.write("dihedral %d %d %d %d %f\n" % (d1+1, d2+1, d3+1, d4+1, v))
+        else:
+            for key, value_list in self.extra_constraints.items():
+                if key == 'freeze' and len(value_list) > 0:
+                    constraints_string += '$' + key + '\n'
+                    for spec_tuple in value_list:
+                        constraints_string += ' '.join(spec_tuple) + '\n'
+                elif key == 'set':
+                    constraints_string += '$' + key + '\n'
+                    for spec_tuple in value_list:
+                        constraints_string += ' '.join(spec_tuple) + '\n'
+                    for d1, d2, d3, d4, v in self.dihedral_idx_values:
+                        constraints_string += ("dihedral %d %d %d %d %f\n" % (d1+1, d2+1, d3+1, d4+1, v))
+                else:
+                    raise KeyError("constraints key %s is not recognized" % key)
+            with open('constraints.txt', 'w') as outfile:
+                outfile.write(constraints_string)             
 
     def load_geomeTRIC_output(self):
         """ Load the optimized geometry and energy into a new molecule object and return """
@@ -213,6 +261,8 @@ class EnginePsi4(QMEngine):
         2. run the job
         """
         assert self.temp_type == 'optimize', "To use native optimization, the input file should have optimize() in it"
+        if self.extra_constraints is not None:
+            raise RuntimeError('extra constraints not supported in Psi4 native optimizations')
         # add the optking command
         self.optkingStr = '\nset optking {\n  fixed_dihedral = ("\n'
         for d1, d2, d3, d4, v in self.dihedral_idx_values:
@@ -352,6 +402,8 @@ class EngineQChem(QMEngine):
         2. run the job
         """
         assert self.temp_type == 'optimize', "To use native optimization, the input file be an opt job"
+        if self.extra_constraints is not None:
+            raise RuntimeError('extra constraints not supported in Q-Chem native optimizations')
         # add the $opt block
         self.optblockStr = '\n$opt\nCONSTRAINT\n'
         for d1, d2, d3, d4, v in self.dihedral_idx_values:
@@ -444,17 +496,36 @@ class EngineTerachem(QMEngine):
 
     def optimize_native(self):
         """
-        Run the constrained optimization, following QChem 5.0 manual.
+        Run the constrained optimization.
         1. write a optimization job input file.
         2. run the job
         """
         assert self.temp_type == 'optimize', "To use native optimization, the input file be an opt job"
-        # add the $opt block
-        self.constraintsStr = '\n$constraint_set\n'
-        for d1, d2, d3, d4, v in self.dihedral_idx_values:
-            # Optking use atom index starting from 1
-            self.constraintsStr += 'dihedral %f %d_%d_%d_%d\n' % (v, d1+1, d2+1, d3+1, d4+1)
-        self.constraintsStr += '$end\n'
+
+        if self.extra_constraints is None:
+            self.constraintsStr = '\n$constraint_set\n'
+            for d1, d2, d3, d4, v in self.dihedral_idx_values:
+                # TeraChem use atom index starting from 1
+                self.constraintsStr += 'dihedral %f %d_%d_%d_%d\n' % (v, d1+1, d2+1, d3+1, d4+1)
+            self.constraintsStr += '$end\n'
+        else:
+            self.constraintsStr = '\n'
+            for key, value_list in self.extra_constraints.items():
+                if key == 'freeze' and len(value_list) > 0:
+                    self.constraintsStr += '$constraint_freeze\n'
+                    for spec_tuple in value_list:
+                        self.constraintsStr += '%s %s\n' % (spec_tuple[0], '_'.join(spec_tuple[1:]))
+                    self.constraintsStr += '$end\n\n'
+                elif key == 'set':
+                    self.constraintsStr += '$constraint_set\n'
+                    for spec_tuple in value_list:
+                        self.constraintsStr += '%s %s %s\n' % (spec_tuple[0], spec_tuple[-1], '_'.join(spec_tuple[1:-1]))
+                    for d1, d2, d3, d4, v in self.dihedral_idx_values:
+                        self.constraintsStr += 'dihedral %f %d_%d_%d_%d\n' % (v, d1+1, d2+1, d3+1, d4+1)
+                    self.constraintsStr += '$end\n'
+                else:
+                    raise KeyError("constraints key %s is not recognized" % key)
+
         # write input file
         self.write_input()
         # run the job

--- a/torsiondrive/qm_engine.py
+++ b/torsiondrive/qm_engine.py
@@ -82,10 +82,11 @@ class QMEngine(object):
         else:
             constraints_string = ''
             for key, value_list in self.extra_constraints.items():
-                if key == 'freeze' and len(value_list) > 0:
-                    constraints_string += '$' + key + '\n'
-                    for spec_tuple in value_list:
-                        constraints_string += ' '.join(spec_tuple) + '\n'
+                if key == 'freeze':
+                    if len(value_list) > 0:
+                        constraints_string += '$' + key + '\n'
+                        for spec_tuple in value_list:
+                            constraints_string += ' '.join(spec_tuple) + '\n'
                 elif key == 'set':
                     constraints_string += '$' + key + '\n'
                     for spec_tuple in value_list:
@@ -512,11 +513,12 @@ class EngineTerachem(QMEngine):
         else:
             self.constraintsStr = '\n'
             for key, value_list in self.extra_constraints.items():
-                if key == 'freeze' and len(value_list) > 0:
-                    self.constraintsStr += '$constraint_freeze\n'
-                    for spec_tuple in value_list:
-                        self.constraintsStr += '%s %s\n' % (spec_tuple[0], '_'.join(spec_tuple[1:]))
-                    self.constraintsStr += '$end\n\n'
+                if key == 'freeze':
+                    if len(value_list) > 0:
+                        self.constraintsStr += '$constraint_freeze\n'
+                        for spec_tuple in value_list:
+                            self.constraintsStr += '%s %s\n' % (spec_tuple[0], '_'.join(spec_tuple[1:]))
+                        self.constraintsStr += '$end\n\n'
                 elif key == 'set':
                     self.constraintsStr += '$constraint_set\n'
                     for spec_tuple in value_list:


### PR DESCRIPTION
This allows the user to set or freeze additional bonds / angles / dihedrals during the torsion drive.  The extra constraints are specified in the same format as geomeTRIC's own `constraint.txt`, with a restricted set of features:

1) Only freezing / setting of extra constraints is allowed; scanning over extra constraints is not well defined because that is torsiondrive's job.
2) Only bond, angle, and dihedral constraints are allowed.