### PR TITLE
Energy thresh

### DIFF
--- a/torsiondrive/dihedral_scanner.py
+++ b/torsiondrive/dihedral_scanner.py
@@ -38,7 +38,7 @@ class DihedralScanner:
     DihedralScanner class is designed to create a dihedral grid, and fill in optimized geometries and energies
     into the grid, by running wavefront propagations of constrained optimizations
     """
-    def __init__(self, engine, dihedrals, grid_spacing, energy_decrease_thresh = 0.00001, init_coords_M=None, verbose=False):
+    def __init__(self, engine, dihedrals, grid_spacing, init_coords_M=None, verbose=False, energy_decrease_thresh = 0.00001):
         """
         inputs:
         -------

--- a/torsiondrive/dihedral_scanner.py
+++ b/torsiondrive/dihedral_scanner.py
@@ -38,7 +38,7 @@ class DihedralScanner:
     DihedralScanner class is designed to create a dihedral grid, and fill in optimized geometries and energies
     into the grid, by running wavefront propagations of constrained optimizations
     """
-    def __init__(self, engine, dihedrals, grid_spacing, init_coords_M=None, verbose=False):
+    def __init__(self, engine, dihedrals, grid_spacing, energy_decrease_thresh = 0.00001, init_coords_M=None, verbose=False):
         """
         inputs:
         -------
@@ -81,7 +81,7 @@ class DihedralScanner:
         # filename for storing finished task result
         self.task_result_fname = 'dihedral_scanner_task_result.p'
         # threshold for determining the energy decrease
-        self.energy_decrease_thresh = 0.00001
+        self.energy_decrease_thresh = energy_decrease_thresh
 
     #----------------------
     # Initializing methods

--- a/torsiondrive/launch.py
+++ b/torsiondrive/launch.py
@@ -75,7 +75,7 @@ def main():
     parser.add_argument('-e', '--engine', type=str, default="psi4", choices=['qchem', 'psi4', 'terachem'], help='Engine for running scan')
     parser.add_argument('-c', '--constraints', type=str, default=None, help='Provide a constraints file in geomeTRIC format for additional freeze or set constraints (geomeTRIC or TeraChem only)')
     parser.add_argument('--native_opt', action='store_true', default=False, help='Use QM program native constrained optimization algorithm. This will turn off geomeTRIC package.')
-    parser.add_argument('--energy_thresh', type=float, default=0.0001, help='Only activate grid points if the new optimization is <thre> lower than the previous lowest energy (in a.u.).')
+    parser.add_argument('--energy_thresh', type=float, default=0.00001, help='Only activate grid points if the new optimization is <thre> lower than the previous lowest energy (in a.u.).')
     parser.add_argument('--wq_port', type=int, default=None, help='Specify port number to use Work Queue to distribute optimization jobs.')
     parser.add_argument('--zero_based_numbering', action='store_true', help='Use zero_based_numbering in dihedrals file.')
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Print more information while running.')

--- a/torsiondrive/launch.py
+++ b/torsiondrive/launch.py
@@ -75,6 +75,7 @@ def main():
     parser.add_argument('-e', '--engine', type=str, default="psi4", choices=['qchem', 'psi4', 'terachem'], help='Engine for running scan')
     parser.add_argument('-c', '--constraints', type=str, default=None, help='Provide a constraints file in geomeTRIC format for additional freeze or set constraints (geomeTRIC or TeraChem only)')
     parser.add_argument('--native_opt', action='store_true', default=False, help='Use QM program native constrained optimization algorithm. This will turn off geomeTRIC package.')
+    parser.add_argument('--energy_thresh', type=float, default=0.0001, help='Only activate grid points if the new optimization is <thre> lower than the previous lowest energy (in a.u.).')
     parser.add_argument('--wq_port', type=int, default=None, help='Specify port number to use Work Queue to distribute optimization jobs.')
     parser.add_argument('--zero_based_numbering', action='store_true', help='Use zero_based_numbering in dihedrals file.')
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Print more information while running.')
@@ -109,7 +110,9 @@ def main():
     init_coords_M = Molecule(args.init_coords) if args.init_coords else None
 
     # create DihedralScanner object
-    scanner = DihedralScanner(engine, dihedrals=dihedral_idxs, grid_spacing=grid_spacing, init_coords_M=init_coords_M, verbose=args.verbose)
+    scanner = DihedralScanner(engine, dihedrals=dihedral_idxs, grid_spacing=grid_spacing,
+                              energy_decrease_thresh = args.energy_thresh,
+                              init_coords_M=init_coords_M, verbose=args.verbose)
     # Run the scan!
     scanner.master()
     # After finish, print result

--- a/torsiondrive/launch.py
+++ b/torsiondrive/launch.py
@@ -111,8 +111,8 @@ def main():
 
     # create DihedralScanner object
     scanner = DihedralScanner(engine, dihedrals=dihedral_idxs, grid_spacing=grid_spacing,
-                              energy_decrease_thresh = args.energy_thresh,
-                              init_coords_M=init_coords_M, verbose=args.verbose)
+                              init_coords_M=init_coords_M, verbose=args.verbose,
+                              energy_decrease_thresh = args.energy_thresh)
     # Run the scan!
     scanner.master()
     # After finish, print result

--- a/torsiondrive/launch.py
+++ b/torsiondrive/launch.py
@@ -75,7 +75,7 @@ def main():
     parser.add_argument('-e', '--engine', type=str, default="psi4", choices=['qchem', 'psi4', 'terachem'], help='Engine for running scan')
     parser.add_argument('-c', '--constraints', type=str, default=None, help='Provide a constraints file in geomeTRIC format for additional freeze or set constraints (geomeTRIC or TeraChem only)')
     parser.add_argument('--native_opt', action='store_true', default=False, help='Use QM program native constrained optimization algorithm. This will turn off geomeTRIC package.')
-    parser.add_argument('--energy_thresh', type=float, default=0.00001, help='Only activate grid points if the new optimization is <thre> lower than the previous lowest energy (in a.u.).')
+    parser.add_argument('--energy_thresh', type=float, default=0.0001, help='Only activate grid points if the new optimization is <thre> lower than the previous lowest energy (in a.u.).')
     parser.add_argument('--wq_port', type=int, default=None, help='Specify port number to use Work Queue to distribute optimization jobs.')
     parser.add_argument('--zero_based_numbering', action='store_true', help='Use zero_based_numbering in dihedrals file.')
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Print more information while running.')


### PR DESCRIPTION
Introduces an energy threshold parameter for deciding when new optimizations are needed.  Setting a higher value of the threshold may improve performance in cases where neighboring grid points decrease the energy by negligible amounts.

The following is an example of a situation we can avoid by setting the threshold parameter to 1e-4, 10x the default value:

```First energy for grid_id (15,) = -1326.258869
Energy for grid_id (45,) decreased from -1326.261757 to -1326.261774
Energy for grid_id (75,) decreased from -1326.267549 to -1326.267567
Energy for grid_id (105,) decreased from -1326.263074 to -1326.263087
Energy for grid_id (135,) decreased from -1326.263081 to -1326.263095
Energy for grid_id (165,) decreased from -1326.269063 to -1326.269077
First energy for grid_id (-15,) = -1326.252348
Energy for grid_id (-45,) decreased from -1326.256946 to -1326.265255
Energy for grid_id (-75,) decreased from -1326.259923 to -1326.265659
Energy for grid_id (-105,) decreased from -1326.258986 to -1326.259000
Energy for grid_id (-135,) decreased from -1326.261135 to -1326.261151
Energy for grid_id (-165,) decreased from -1326.268240 to -1326.268254
Scan Status at 13047 s
 o + o + o + o + o + o + o + o + o + o + o + o +
```