### PR TITLE
fix small bug that cause error for grid spacing of 24

### DIFF
--- a/torsiondrive/dihedral_scanner.py
+++ b/torsiondrive/dihedral_scanner.py
@@ -116,7 +116,9 @@ class DihedralScanner:
                     print("Warning! dihedral values inconsistent with check_grid_id")
                     print('dihedral_values', dihedral_values, 'check_grid_id', check_grid_id)
                     break
-        dihedral_id = (np.round(dihedral_values / self.grid_spacing) * self.grid_spacing).astype(int)
+        # here we shift the dihedral by +180 then shift back because -180 the actual origin of the grid
+        # this allows grid_spacing of 24
+        dihedral_id = (np.round((dihedral_values + 180) / self.grid_spacing) * self.grid_spacing - 180).astype(int)
         # we return a tuples as the grid_id
         return tuple([normalize_dihedral(d) for d in dihedral_id])
 


### PR DESCRIPTION
Thanks to Mudong pointed out, when using grid spacing of 24, the current code have an error about `grid_id` not found.

This is caused by a small bug that maps the real dihedral value to the grid, which previously did not take into account that 0 degree may not be in the grid because -180 is the actual origin. In the case of 24 grid spacing, the grid ids are `-156, -132, ..., -12, +12, ...`

The small fix should solve the issue, where we shift the value by +180 before rounding, then shift back.