### PR TITLE
Implement dihedral range limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ matrix:
     - os: linux
       python: 3.6
       env: PYTHON_VER=3.6
-    - os: linux
-      python: 3.5
-      env: PYTHON_VER=3.5
 
 before_install:
   # Additional info about the build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,6 @@
 environment:
 
   matrix:
-    - PYTHON: "C:\\Miniconda35-x64"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Miniconda36-x64"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -1,11 +1,11 @@
 name: test
 channels:
   - conda-forge
-  - psi4
   - molssi
+  - psi4
 dependencies:
     # Psi test depends
-  - psi4
+  - psi4=1.2.1
   - qcengine
 
     # geomeTRIC base depends

--- a/torsiondrive/dihedral_scanner.py
+++ b/torsiondrive/dihedral_scanner.py
@@ -458,7 +458,8 @@ class DihedralScanner:
         m = Molecule()
         m.elem = list(self.engine.M.elem)
         m.qm_energies, m.xyzs, m.comms = [], [], []
-        for gid in self.grid_ids:
+        # only print grid with energies
+        for gid in self.grid_energies:
             m.qm_energies.append(self.grid_energies[gid])
             m.xyzs.append(self.grid_final_geometries[gid])
             m.comms.append("Dihedral %s Energy %.9f" % (str(gid), self.grid_energies[gid]))

--- a/torsiondrive/dihedral_scanner.py
+++ b/torsiondrive/dihedral_scanner.py
@@ -38,7 +38,7 @@ class DihedralScanner:
     DihedralScanner class is designed to create a dihedral grid, and fill in optimized geometries and energies
     into the grid, by running wavefront propagations of constrained optimizations
     """
-    def __init__(self, engine, dihedrals, grid_spacing, init_coords_M=None, verbose=False, energy_decrease_thresh = 0.00001):
+    def __init__(self, engine, dihedrals, grid_spacing, init_coords_M=None, energy_decrease_thresh=0.00001, dihedral_ranges=None, verbose=False):
         """
         inputs:
         -------
@@ -59,14 +59,22 @@ class DihedralScanner:
             self.dihedrals.append(dihedral_tuple)
         self.grid_dim = len(self.dihedrals)
         for gs in grid_spacing:
-            assert (0 < gs < 360) and (360 % gs == 0), "grid_spacing %s is not valid, all values should be a divisor of 360" % grid_spacing
-        assert len(grid_spacing) == self.grid_dim, "Number of grid spacings %d is not consistent with number of dihedrals %d" % (len(grid_spacing), self.grid_dim)
+            assert (0 < gs < 360) and (360 % gs == 0), f"grid_spacing {grid_spacing} is not valid, all values should be a divisor of 360"
+        assert len(grid_spacing) == self.grid_dim, f"Number of grid spacings {len(grid_spacing)} is not consistent with number of dihedrals {self.grid_dim}"
         self.grid_spacing = tuple(map(int, grid_spacing))
         self.setup_grid()
+        # validate dihedral ranges
+        if dihedral_ranges:
+            assert all(low >= 180 and high <= 180 and low < high for l, r in dihedral_ranges), \
+                f'Dihedral ranges {dihedral_ranges} mistaken, range should be within [-180, 180]'
+            if verbose:
+                print(f"Dihedral scan initialized with range limit {dihedral_ranges}")
+        self.dihedral_ranges = dihedral_ranges if dihedral_ranges is not None else []
         self.opt_queue = PriorityQueue()
         # try to use init_coords_M first, if not given, use M in engine's template
         # `for m in init_coords_M` doesn't work since m.measure_dihedrals will fail because it has different m.xyzs shape
         self.init_coords_M = [init_coords_M[i] for i in range(len(init_coords_M))] if init_coords_M is not None else [self.engine.M]
+        # store verbose flag for later printing
         self.verbose = verbose
         # dictionary that stores the lowest energy for each grid point
         self.grid_energies = dict()
@@ -233,8 +241,10 @@ class DihedralScanner:
                 # every neighbor grid point will get one new task
                 for neighbor_gid in self.grid_neighbors(grid_id):
                     task = m, grid_id, neighbor_gid
-                    # all jobs are pushed with the same priority for now, can be adjusted here
-                    self.opt_queue.push(task)
+                    # validate task before pushing
+                    if self.validate_task(task):
+                        # all jobs are pushed with the same priority for now, can be adjusted here
+                        self.opt_queue.push(task)
             # check if all jobs finished
             if len(self.opt_queue) == 0 and len(self.running_job_path_info) == 0:
                 print("All optimizations converged at lowest energy. Job Finished!")
@@ -247,6 +257,31 @@ class DihedralScanner:
     # Utility methods Called by Master
     #----------------------------------
 
+    def validate_task(self, task):
+        """
+        Validate a constrained optimization task before pushing to the queue.
+        This is useful to limit the dihedrals into a range of interest.
+
+        Parameters
+        ----------
+        task: (m, from_grid_id, to_grid_id)
+            A constrained optimization task
+
+        Returns
+        -------
+        isValid: bool
+            True if the task is valid
+        """
+        m, from_grid_id, to_grid_id = task
+        if self.dihedral_ranges:
+            for d, d_range in zip(to_grid_id, self.dihedral_ranges):
+                low, high = d_range
+                if d < low or d > high:
+                    if self.verbose:
+                        print(f"Task with target grid_id {to_grid_id} skipped because it doesn't fit in limited range {low}--{high}")
+                    return False
+        return True
+
     def push_initial_opt_tasks(self):
         """
         Push a set of initial tasks to self.opt_queue
@@ -255,9 +290,10 @@ class DihedralScanner:
         for m in self.init_coords_M:
             from_grid_id = to_grid_id = self.get_dihedral_id(m)
             task = (m, from_grid_id, to_grid_id)
-            self.opt_queue.push(task)
+            if self.validate_task(task):
+                self.opt_queue.push(task)
         if self.verbose:
-            print("%d initial tasks pushed to opt_queue" % len(self.init_coords_M))
+            print(f"{len(self.init_coords_M)} initial tasks pushed to opt_queue")
 
     def save_task_cache(self, job_path, m_init, m_final, final_energy):
         """
@@ -267,7 +303,6 @@ class DihedralScanner:
         task_result = {'initial_geo': m_init.xyzs[0], 'final_geo': m_final.xyzs[0], 'final_energy': final_energy}
         with open(os.path.join(self.rootpath, job_path, self.task_result_fname), 'wb') as pickleout:
             pickle.dump(task_result, pickleout)
-
 
     def restore_task_cache(self):
         """
@@ -288,6 +323,8 @@ class DihedralScanner:
         assert len(self.dihedrals) == len(scanner_settings['dihedrals']), err_msg
         assert np.array_equal(np.array(self.dihedrals), np.array(scanner_settings['dihedrals'])), err_msg
         assert np.array_equal(self.grid_spacing, scanner_settings['grid_spacing']), err_msg
+        assert self.energy_decrease_thresh == scanner_settings['energy_decrease_thresh'], err_msg
+        assert np.array_equal(self.dihedral_ranges, scanner_settings['dihedral_ranges']), err_msg
         # read all finished jobs in tmp folder
         self.tmp_folder_dict = dict()
         n_cache = 0
@@ -319,7 +356,8 @@ class DihedralScanner:
         assert hasattr(self, 'grid_ids'), 'Call self.setup_grid() first'
         os.mkdir(self.tmp_folder_name)
         # save current scan settings
-        scanner_settings = {'dihedrals': self.dihedrals, 'grid_spacing': self.grid_spacing}
+        scanner_settings = {'dihedrals': self.dihedrals, 'grid_spacing': self.grid_spacing,
+                            'energy_decrease_thresh': self.energy_decrease_thresh, 'dihedral_ranges': self.dihedral_ranges}
         settings_fname = os.path.join(self.rootpath, self.tmp_folder_name, 'scanner_settings.json')
         with open(settings_fname, 'w') as jsonfile:
             json.dump(scanner_settings, jsonfile)

--- a/torsiondrive/launch.py
+++ b/torsiondrive/launch.py
@@ -73,6 +73,9 @@ def load_dihedralfile(dihedralfile, zero_based_numbering=False):
                 if len(ls) == 4:
                     dihedral_idxs.append([int(i)-1 for i in ls])
                 elif len(ls) == 6:
+                    # insert default values [-180, 180] for missing values above
+                    for _ in range(len(dihedral_idxs) - len(dihedral_ranges)):
+                        dihedral_ranges.append([-180, 180])
                     dihedral_idxs.append([int(i)-1 for i in ls[:4]])
                     dihedral_ranges.append([int(v) for v in ls[4:]])
                 else:
@@ -83,7 +86,10 @@ def load_dihedralfile(dihedralfile, zero_based_numbering=False):
     # check all dihedrals valid (>= 0)
     assert all(i >= 0 for d in dihedral_idxs for i in d), f'Dihedral indices {dihedral_idxs} error, all should >= 0'
     # check all ranges valid [-180, 180]
-    assert all(low >= 180 and high <= 180 and low < high for l, r in dihedral_ranges), f'Dihedral ranges {dihedral_ranges} mistaken, range should be within [-180, 180]'
+    assert all(low >= -180 and high <= 180 and low < high for low, high in dihedral_ranges), f'Dihedral ranges {dihedral_ranges} mistaken, range should be within [-180, 180]'
+    # check dihedral_idxs and dihedral_ranges have same length
+    if dihedral_ranges != []:
+        assert len(dihedral_idxs) == len(dihedral_ranges), f'Dihedral ranges {dihedral_ranges} length not consistent with dihedral idxs {dihedral_idxs}'
     return dihedral_idxs, dihedral_ranges
 
 def create_engine(enginename, inputfile=None, work_queue_port=None, native_opt=False, extra_constraints=None):

--- a/torsiondrive/launch.py
+++ b/torsiondrive/launch.py
@@ -30,7 +30,7 @@ def load_dihedralfile(dihedralfile, zero_based_numbering=False):
     If a fifth and sixth number are given in the line, they will be recognized as the lower
     and upper range limit of the dihedral angle, i.e. Reading the file
 
-    # dihedral definition by atom indices starting from 0
+    # dihedral definition by atom indices starting from 1
     # i     j     k     j   (range_low)   (range_high)
       1     2     3     4     -120            120
       2     3     4     5      -90            150

--- a/torsiondrive/launch.py
+++ b/torsiondrive/launch.py
@@ -11,27 +11,52 @@ def load_dihedralfile(dihedralfile, zero_based_numbering=False):
     """
     Load definition of dihedral from a text file, i.e. Loading the file
 
-    # dihedral definition by atom indices starting from 0
     # i     j     k     j
       1     2     3     4
       2     3     4     5
 
     Will return dihedral_idxs = [(0,1,2,3), (1,2,3,4)]
 
-    If a comment line
-    #zero_based_numbering
-    is found at the beginning of the file, or
-    parameter zero_based_numbering == True
-    reading will become
+    If a comment line #zero_based_numbering is found at the beginning of the file,
+    or parameter zero_based_numbering == True, atom indices will be zero-based
 
+    #zero_based_numbering
     # i     j     k     j
       1     2     3     4
       2     3     4     5
 
     Returns dihedral_idxs = [(1,2,3,4), (2,3,4,5)]
 
+    If a fifth and sixth number are given in the line, they will be recognized as the lower
+    and upper range limit of the dihedral angle, i.e. Reading the file
+
+    # dihedral definition by atom indices starting from 0
+    # i     j     k     j   (range_low)   (range_high)
+      1     2     3     4     -120            120
+      2     3     4     5      -90            150
+
+    will generate two dihedrals, the first dihedral (0,1,2,3) have a range limit [-120, 120],
+    the second dihedral (1,2,3,4) have the range limit [-90, 150], both ends inclusive.
+
+    Parameters
+    ----------
+    dihedralfile: str
+        filename that contains the dihedral angle definition
+    zero_based_numbering: bool, default False
+        Setting to true means atom indices in the file are zero-based
+
+    Returns
+    -------
+    dihedral_idxs: list of list of 4 integers
+        dihedrals are defined in 4 atom indices, e.g. [[i0,j0,k0,l0], [i1,j1,k1,l1]]
+        The indices are zero-based.
+    dihedral_ranges: list of list of 2 numbers
+        dihedral ranges should be either empty (no limit), or two numbers [low, high],
+        e.g. [[-120, 120], [-90, 150]]
+        low >= -180, high <= 180, low < high
     """
     dihedral_idxs = []
+    dihedral_ranges = []
     with open(dihedralfile) as infile:
         for line in infile:
             line = line.strip()
@@ -43,12 +68,23 @@ def load_dihedralfile(dihedralfile, zero_based_numbering=False):
                 elif comment == 'one_based_numbering':
                     if zero_based_numbering == True:
                         raise ValueError("Can not specify both zero_based_numbering and one_based_indexing.")
-                continue
-            if zero_based_numbering == False:
-                dihedral_idxs.append([int(i)-1 for i in line.split()])
             else:
-                dihedral_idxs.append([int(i) for i in line.split()])
-    return dihedral_idxs
+                ls = line.split()
+                if len(ls) == 4:
+                    dihedral_idxs.append([int(i)-1 for i in ls])
+                elif len(ls) == 6:
+                    dihedral_idxs.append([int(i)-1 for i in ls[:4]])
+                    dihedral_ranges.append([int(v) for v in ls[4:]])
+                else:
+                    raise ValueError(f'Input line can not be recognized, should be 4 or 6 numbers\n{line}')
+    # conver dihedral indices if zero based
+    if zero_based_numbering:
+        dihedral_idxs = [[i+i for i in d] for d in dihedral_idxs]
+    # check all dihedrals valid (>= 0)
+    assert all(i >= 0 for d in dihedral_idxs for i in d), f'Dihedral indices {dihedral_idxs} error, all should >= 0'
+    # check all ranges valid [-180, 180]
+    assert all(low >= 180 and high <= 180 and low < high for l, r in dihedral_ranges), f'Dihedral ranges {dihedral_ranges} mistaken, range should be within [-180, 180]'
+    return dihedral_idxs, dihedral_ranges
 
 def create_engine(enginename, inputfile=None, work_queue_port=None, native_opt=False, extra_constraints=None):
     """
@@ -75,7 +111,7 @@ def main():
     parser.add_argument('-e', '--engine', type=str, default="psi4", choices=['qchem', 'psi4', 'terachem'], help='Engine for running scan')
     parser.add_argument('-c', '--constraints', type=str, default=None, help='Provide a constraints file in geomeTRIC format for additional freeze or set constraints (geomeTRIC or TeraChem only)')
     parser.add_argument('--native_opt', action='store_true', default=False, help='Use QM program native constrained optimization algorithm. This will turn off geomeTRIC package.')
-    parser.add_argument('--energy_thresh', type=float, default=0.0001, help='Only activate grid points if the new optimization is <thre> lower than the previous lowest energy (in a.u.).')
+    parser.add_argument('--energy_thresh', type=float, default=0.00001, help='Only activate grid points if the new optimization is <thre> lower than the previous lowest energy (in a.u.).')
     parser.add_argument('--wq_port', type=int, default=None, help='Specify port number to use Work Queue to distribute optimization jobs.')
     parser.add_argument('--zero_based_numbering', action='store_true', help='Use zero_based_numbering in dihedrals file.')
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Print more information while running.')
@@ -85,7 +121,9 @@ def main():
     print(' '.join(sys.argv))
 
     # parse the dihedral file
-    dihedral_idxs = load_dihedralfile(args.dihedralfile, args.zero_based_numbering)
+    if args.zero_based_numbering is True:
+        print("The use of command line --zero_based_numbering is deprecated and will be removed in the future. Please use #zero_based_numbering in dihedralfile")
+    dihedral_idxs, dihedral_ranges = load_dihedralfile(args.dihedralfile, args.zero_based_numbering)
     grid_dim = len(dihedral_idxs)
 
     # parse additional constraints
@@ -110,9 +148,8 @@ def main():
     init_coords_M = Molecule(args.init_coords) if args.init_coords else None
 
     # create DihedralScanner object
-    scanner = DihedralScanner(engine, dihedrals=dihedral_idxs, grid_spacing=grid_spacing,
-                              init_coords_M=init_coords_M, verbose=args.verbose,
-                              energy_decrease_thresh = args.energy_thresh)
+    scanner = DihedralScanner(engine, dihedrals=dihedral_idxs, dihedral_ranges=dihedral_ranges, grid_spacing=grid_spacing, init_coords_M=init_coords_M,
+                              energy_decrease_thresh=args.energy_thresh,  verbose=args.verbose)
     # Run the scan!
     scanner.master()
     # After finish, print result

--- a/torsiondrive/qm_engine.py
+++ b/torsiondrive/qm_engine.py
@@ -426,7 +426,7 @@ class EngineQChem(QMEngine):
         self.M.xyzs = [np.array(coords, dtype=float)]
         self.M.build_topology()
 
-    def write_input(self, filename='job.in'):
+    def write_input(self, filename='qc.in'):
         """ Write QChem input using Molecule Class """
         assert hasattr(self, 'qchem_temp'), "self.qchem_temp not set, call load_input() first"
         with open(filename, 'w') as outfile:

--- a/torsiondrive/qm_engine.py
+++ b/torsiondrive/qm_engine.py
@@ -140,12 +140,12 @@ class QMEngine(object):
 
     def load_geomeTRIC_output(self):
         """ Load the optimized geometry and energy into a new molecule object and return """
-        # the name of the file is consistent with the --prefix tdavcft option,
-        # this also requires the input file NOT be named to sth like tdavcft.in
-        # otherwise the output will become tdavcft_optim.xyz
-        if not os.path.isfile('tdavcft.xyz'):
-            raise OSError("geomeTRIC output tdavcft.xyz file not found")
-        m = Molecule('tdavcft.xyz')[-1]
+        # the name of the file is consistent with the --prefix tdrive option,
+        # this also requires the input file NOT be named to sth like tdrive.in
+        # otherwise the output will become tdrive_optim.xyz
+        if not os.path.isfile('tdrive.xyz'):
+            raise OSError("geomeTRIC output tdrive.xyz file not found")
+        m = Molecule('tdrive.xyz')[-1]
         m.qm_energies = [float(m.comms[0].rsplit(maxsplit=1)[-1])]
         return m
 
@@ -332,7 +332,7 @@ class EnginePsi4(QMEngine):
         # step 2
         self.write_input('input.dat')
         # step 3
-        self.run('geometric-optimize --prefix tdavcft --qccnv --reset --epsilon 0.0 --psi4 input.dat constraints.txt > optimize.log', input_files=['input.dat', 'constraints.txt'], output_files=['optimize.log', 'opt.xyz', 'energy.txt'])
+        self.run('geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 --psi4 input.dat constraints.txt > optimize.log', input_files=['input.dat', 'constraints.txt'], output_files=['optimize.log', 'opt.xyz', 'energy.txt'])
 
     def load_native_output(self, filename='output.dat'):
         """ Load the optimized geometry and energy into a new molecule object and return """
@@ -473,7 +473,7 @@ class EngineQChem(QMEngine):
         # step 2
         self.write_input('qc.in')
         # step 3
-        self.run('geometric-optimize --prefix tdavcft --qccnv --reset --epsilon 0.0 --qchem qc.in constraints.txt > optimize.log', input_files=['qc.in', 'constraints.txt'], output_files=['optimize.log', 'opt.xyz', 'energy.txt'])
+        self.run('geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 --qchem qc.in constraints.txt > optimize.log', input_files=['qc.in', 'constraints.txt'], output_files=['optimize.log', 'opt.xyz', 'energy.txt'])
 
     def load_native_output(self, filename='qc.out'):
         """ Load the optimized geometry and energy into a new molecule object and return """
@@ -590,7 +590,7 @@ class EngineTerachem(QMEngine):
         # step 2
         self.write_input()
         # step 3
-        self.run('geometric-optimize --prefix tdavcft --qccnv --reset --epsilon 0.0 run.in constraints.txt > optimize.log', input_files=['run.in', self.tera_geo_file, 'constraints.txt'], output_files=['optimize.log', 'opt.xyz', 'energy.txt'])
+        self.run('geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 run.in constraints.txt > optimize.log', input_files=['run.in', self.tera_geo_file, 'constraints.txt'], output_files=['optimize.log', 'opt.xyz', 'energy.txt'])
 
     def load_native_output(self):
         """ Load the optimized geometry and energy into a new molecule object and return """

--- a/torsiondrive/tests/test_stack.py
+++ b/torsiondrive/tests/test_stack.py
@@ -73,8 +73,8 @@ class Psi4QCEngineEngine(QMEngine):
         """ Load the optimized geometry and energy from self.out_json_dict into a new molecule object and return """
         out_json_dict = self.stored_results.pop(os.getcwd())
         mdict = out_json_dict['final_molecule']
-        #import IPython
-        #IPython.embed()
+        if not mdict:
+            raise RuntimeError("QCEngine failed.\n" + str(out_json_dict))
         m = Molecule()
         m.xyzs = [np.array(mdict['geometry']).reshape(-1, 3) * bohr2ang]
         m.elem = mdict['symbols']

--- a/torsiondrive/tests/test_stack.py
+++ b/torsiondrive/tests/test_stack.py
@@ -44,7 +44,7 @@ class Psi4QCEngineEngine(QMEngine):
             'set': [{'type': 'dihedral', 'indices': [d1, d2, d3, d4], 'value': v} for d1, d2, d3, d4, v in self.dihedral_idx_values]
         }
         qc_schema_input = {
-            "schema_name": "qc_schema_input",
+            "schema_name": "qcschema_input",
             "schema_version": 1,
             "driver": "gradient",
             "model": {
@@ -54,7 +54,7 @@ class Psi4QCEngineEngine(QMEngine):
             "keywords": {}
         }
         in_json_dict = {
-            "schema_name": "qc_schema_optimization_input",
+            "schema_name": "qcschema_optimization_input",
             "schema_version": 1,
             "keywords": {
                 "coordsys": "tric",
@@ -73,6 +73,8 @@ class Psi4QCEngineEngine(QMEngine):
         """ Load the optimized geometry and energy from self.out_json_dict into a new molecule object and return """
         out_json_dict = self.stored_results.pop(os.getcwd())
         mdict = out_json_dict['final_molecule']
+        #import IPython
+        #IPython.embed()
         m = Molecule()
         m.xyzs = [np.array(mdict['geometry']).reshape(-1, 3) * bohr2ang]
         m.elem = mdict['symbols']

--- a/torsiondrive/tests/test_stack_api.py
+++ b/torsiondrive/tests/test_stack_api.py
@@ -82,7 +82,7 @@ class SimpleServer:
             'set': [{'type': 'dihedral', 'indices': list(d), 'value': v} for d, v in zip(self.dihedrals, dihedral_values)]
         }
         qc_schema_input = {
-            "schema_name": "qc_schema_input",
+            "schema_name": "qcschema_input",
             "schema_version": 1,
             "driver": "gradient",
             "model": {
@@ -93,7 +93,7 @@ class SimpleServer:
         }
 
         geometric_input_dict = {
-            "schema_name": "qc_schema_optimization_input",
+            "schema_name": "qcschema_optimization_input",
             "schema_version": 1,
             "keywords": {
                 "coordsys": "tric",

--- a/torsiondrive/tests/test_torsiondrive.py
+++ b/torsiondrive/tests/test_torsiondrive.py
@@ -3,8 +3,14 @@ Unit and regression test for the torsiondrive package.
 """
 
 import pytest
-import os, sys, subprocess, filecmp, shutil, json
+import os
+import sys
+import subprocess
+import filecmp
+import shutil
+import json
 import numpy as np
+import torsiondrive
 from torsiondrive.dihedral_scanner import DihedralScanner, Molecule
 from torsiondrive.qm_engine import QMEngine, EnginePsi4, EngineQChem, EngineTerachem
 from torsiondrive.priority_queue import PriorityQueue
@@ -73,12 +79,11 @@ def test_qm_engine():
     assert engine.load_native_output() is None
 
 
-def test_engine_psi4_native():
+def test_engine_psi4_native(tmpdir):
     """
     Testing EnginePsi4
     """
-    os.mkdir('test.tmp')
-    os.chdir('test.tmp')
+    tmpdir.chdir()
     with open('input.dat', 'w') as psi4in:
         psi4in.write("""
 molecule {
@@ -102,15 +107,12 @@ optimize('mp2')
         assert pytest.approx(-150.9647, 0.0001) == m.qm_energies[0]
     except subprocess.CalledProcessError:
         pass
-    os.chdir('..')
-    shutil.rmtree('test.tmp')
 
-def test_engine_psi4_geometric():
+def test_engine_psi4_geometric(tmpdir):
     """
     Testing EnginePsi4 by geomeTRIC
     """
-    os.mkdir('test.tmp')
-    os.chdir('test.tmp')
+    tmpdir.chdir()
     with open('input.dat', 'w') as psi4in:
         psi4in.write("""
 molecule {
@@ -134,15 +136,12 @@ gradient('mp2')
         assert pytest.approx(-150.9647, 0.0001) == m.qm_energies[0]
     except subprocess.CalledProcessError:
         pass
-    os.chdir('..')
-    shutil.rmtree('test.tmp')
 
-def test_engine_qchem_native():
+def test_engine_qchem_native(tmpdir):
     """
     Testing EngineQChem
     """
-    os.mkdir('test.tmp')
-    os.chdir('test.tmp')
+    tmpdir.chdir()
     with open('qc.in', 'w') as outfile:
         outfile.write("""
         $molecule
@@ -169,15 +168,12 @@ def test_engine_qchem_native():
         assert pytest.approx(-149.9420, 0.0001) == m.qm_energies[0]
     except subprocess.CalledProcessError:
         pass
-    os.chdir('..')
-    shutil.rmtree('test.tmp')
 
-def test_engine_qchem_geometric():
+def test_engine_qchem_geometric(tmpdir):
     """
     Testing EngineQChem by geomeTRIC
     """
-    os.mkdir('test.tmp')
-    os.chdir('test.tmp')
+    tmpdir.chdir()
     with open('qc.in', 'w') as outfile:
         outfile.write("""
         $molecule
@@ -204,15 +200,12 @@ def test_engine_qchem_geometric():
         assert pytest.approx(-149.9420, 0.0001) == m.qm_energies[0]
     except subprocess.CalledProcessError:
         pass
-    os.chdir('..')
-    shutil.rmtree('test.tmp')
 
-def test_engine_terachem_native():
+def test_engine_terachem_native(tmpdir):
     """
     Testing EngineTerachem
     """
-    os.mkdir('test.tmp')
-    os.chdir('test.tmp')
+    tmpdir.chdir()
     with open('run.in', 'w') as outfile:
         outfile.write("""
         coordinates start.xyz
@@ -241,15 +234,12 @@ def test_engine_terachem_native():
         assert pytest.approx(-151.5334, 0.0001) == m.qm_energies[0]
     except subprocess.CalledProcessError:
         pass
-    os.chdir('..')
-    shutil.rmtree('test.tmp')
 
-def test_engine_terachem_geometric():
+def test_engine_terachem_geometric(tmpdir):
     """
     Testing EngineTerachem by geomeTRIC
     """
-    os.mkdir('test.tmp')
-    os.chdir('test.tmp')
+    tmpdir.chdir()
     with open('run.in', 'w') as outfile:
         outfile.write("""
         coordinates start.xyz
@@ -278,91 +268,97 @@ def test_engine_terachem_geometric():
         assert pytest.approx(-151.5334, 0.0001) == m.qm_energies[0]
     except subprocess.CalledProcessError:
         pass
-    os.chdir('..')
-    shutil.rmtree('test.tmp')
 
-def test_reproduce_1D_examples():
+@pytest.fixture(scope="module")
+def example_path(tmpdir_factory):
+    """ Pytest fixture funtion to download the examples, decompress and return the path to the example/ folder """
+    # tmpdir_factory is a pytest built-in fixture that has "session" scope
+    tmpdir = tmpdir_factory.mktemp('torsiondrive_test_tmp')
+    tmpdir.chdir()
+    example_version = '0.9.4'
+    url = f'https://github.com/lpwgroup/torsiondrive_examples/archive/v{example_version}.tar.gz'
+    subprocess.run(f'wget -nc -q {url}', shell=True, check=True)
+    subprocess.run(f'tar zxf v{example_version}.tar.gz', shell=True, check=True)
+    os.chdir(f'torsiondrive_examples-{example_version}/examples')
+    return os.getcwd()
+
+def test_reproduce_1D_examples(example_path):
     """
     Testing Reproducing examples/hooh-1d
     """
     from torsiondrive import launch
-    this_file_folder = os.path.dirname(os.path.realpath(__file__))
-    example_path = os.path.join(this_file_folder, '..', '..', 'examples')
-    os.chdir(example_path)
-    subprocess.call('tar zxf hooh-1d.tar.gz ', shell=True)
     # reproduce psi4 local geomeTRIC
+    os.chdir(example_path)
     os.chdir('hooh-1d/psi4/run_local/geomeTRIC')
+    subprocess.run('tar zxf opt_tmp.tar.gz', shell=True, check=True)
     shutil.copy('scan.xyz', 'orig_scan.xyz')
-    dihedral_idxs = launch.load_dihedralfile('dihedrals.txt', zero_based_numbering=True)
+    dihedral_idxs, dihedral_ranges = launch.load_dihedralfile('dihedrals.txt')
     engine = launch.create_engine('psi4', inputfile='input.dat')
     scanner = DihedralScanner(engine, dihedrals=dihedral_idxs, grid_spacing=[15], verbose=True)
     scanner.master()
     assert filecmp.cmp('scan.xyz', 'orig_scan.xyz')
-    os.chdir(example_path)
     # reproduce psi4 local native_opt
+    os.chdir(example_path)
     os.chdir('hooh-1d/psi4/run_local/native_opt')
+    subprocess.run('tar zxf opt_tmp.tar.gz', shell=True, check=True)
     shutil.copy('scan.xyz', 'orig_scan.xyz')
-    dihedral_idxs = launch.load_dihedralfile('dihedrals.txt', zero_based_numbering=True)
+    dihedral_idxs, dihedral_ranges = launch.load_dihedralfile('dihedrals.txt')
     engine = launch.create_engine('psi4', inputfile='input.dat', native_opt=True)
     scanner = DihedralScanner(engine, dihedrals=dihedral_idxs, grid_spacing=[15], verbose=True)
     scanner.master()
     assert filecmp.cmp('scan.xyz', 'orig_scan.xyz')
-    os.chdir(example_path)
     # reproduce qchem local geomeTRIC
+    os.chdir(example_path)
     os.chdir('hooh-1d/qchem/run_local/geomeTRIC')
+    subprocess.run('tar zxf opt_tmp.tar.gz', shell=True, check=True)
     shutil.copy('scan.xyz', 'orig_scan.xyz')
-    dihedral_idxs = launch.load_dihedralfile('dihedrals.txt', zero_based_numbering=True)
+    dihedral_idxs, dihedral_ranges = launch.load_dihedralfile('dihedrals.txt')
     engine = launch.create_engine('qchem', inputfile='qc.in')
     scanner = DihedralScanner(engine, dihedrals=dihedral_idxs, grid_spacing=[15], verbose=True)
     scanner.master()
     assert filecmp.cmp('scan.xyz', 'orig_scan.xyz')
-    os.chdir(example_path)
     # reproduce terachem local geomeTRIC
+    os.chdir(example_path)
     os.chdir('hooh-1d/terachem/run_local/geomeTRIC')
+    subprocess.run('tar zxf opt_tmp.tar.gz', shell=True, check=True)
     shutil.copy('scan.xyz', 'orig_scan.xyz')
-    dihedral_idxs = launch.load_dihedralfile('dihedrals.txt', zero_based_numbering=True)
+    dihedral_idxs, dihedral_ranges = launch.load_dihedralfile('dihedrals.txt')
     engine = launch.create_engine('terachem', inputfile='run.in')
     scanner = DihedralScanner(engine, dihedrals=dihedral_idxs, grid_spacing=[15], verbose=True)
     scanner.master()
     assert filecmp.cmp('scan.xyz', 'orig_scan.xyz')
 
-def test_reproduce_2D_example():
+def test_reproduce_2D_example(example_path):
     """
     Testing Reproducing examples/propanol-2d
     """
     from torsiondrive import launch
-    this_file_folder = os.path.dirname(os.path.realpath(__file__))
-    example_path = os.path.join(this_file_folder, '..', '..', 'examples')
-    os.chdir(example_path)
-    subprocess.call('tar zxf propanol-2d.tar.gz', shell=True)
     # reproduce qchem work_queue geomeTRIC
+    os.chdir(example_path)
     os.chdir('propanol-2d/work_queue_qchem_geomeTRIC')
+    subprocess.run('tar zxf opt_tmp.tar.gz', shell=True, check=True)
     shutil.copy('scan.xyz', 'orig_scan.xyz')
     argv = sys.argv[:]
-    sys.argv = 'torsiondrive-launch qc.in dihedrals.txt -e qchem -g 15 --zero_based_numbering -v'.split()
+    sys.argv = 'torsiondrive-launch qc.in dihedrals.txt -e qchem -g 15 -v'.split()
     launch.main()
     assert filecmp.cmp('scan.xyz', 'orig_scan.xyz')
-    os.chdir(example_path)
     # reproduce qchem work_queue native_opt
+    os.chdir(example_path)
     os.chdir('propanol-2d/work_queue_qchem_native_opt')
+    subprocess.run('tar zxf opt_tmp.tar.gz', shell=True, check=True)
     shutil.copy('scan.xyz', 'orig_scan.xyz')
-    shutil.copy('scan.xyz', 'orig_scan.xyz')
-    sys.argv = 'torsiondrive-launch qc.in dihedrals.txt -e qchem -g 15 --native_opt --zero_based_numbering -v'.split()
+    sys.argv = 'torsiondrive-launch qc.in dihedrals.txt -e qchem -g 15 --native_opt -v'.split()
     launch.main()
     sys.argv = argv
     assert filecmp.cmp('scan.xyz', 'orig_scan.xyz')
-    os.chdir(example_path)
 
-def test_reproduce_api_example():
+def test_reproduce_api_example(example_path):
     """
     Testing Reproducing examples/api_example
     """
     from torsiondrive import td_api
-    this_file_folder = os.path.dirname(os.path.realpath(__file__))
-    example_path = os.path.join(this_file_folder, '..', '..', 'examples')
-    os.chdir(example_path)
-    subprocess.call('tar zxf api_example.tar.gz', shell=True)
     # test running api
+    os.chdir(example_path)
     os.chdir('api_example')
     orig_next_jobs = json.load(open('next_jobs.json'))
     current_state = json.load(open('current_state.json'))
@@ -373,7 +369,6 @@ def test_reproduce_api_example():
     loaded_state = td_api.current_state_json_load(current_state)
     td_api.current_state_json_dump(loaded_state, 'new_current_state.json')
     assert filecmp.cmp('current_state.json', 'new_current_state.json')
-    os.chdir(example_path)
 
 @pytest.mark.skipif("work_queue" not in sys.modules, reason='work_queue not found')
 def test_work_queue():

--- a/torsiondrive/tests/test_torsiondrive.py
+++ b/torsiondrive/tests/test_torsiondrive.py
@@ -352,6 +352,21 @@ def test_reproduce_2D_example(example_path):
     sys.argv = argv
     assert filecmp.cmp('scan.xyz', 'orig_scan.xyz')
 
+def test_reproduce_range_limit_example(example_path):
+    """
+    Testing Reproducing examples/range_limited
+    """
+    from torsiondrive import launch
+    # reproduce qchem work_queue geomeTRIC
+    os.chdir(example_path)
+    os.chdir('range_limited')
+    subprocess.run('tar zxf opt_tmp.tar.gz', shell=True, check=True)
+    shutil.copy('scan.xyz', 'orig_scan.xyz')
+    argv = sys.argv[:]
+    sys.argv = 'torsiondrive-launch qc.in dihedrals.txt -g 15 30 -e qchem -v'.split()
+    launch.main()
+    assert filecmp.cmp('scan.xyz', 'orig_scan.xyz')
+
 def test_reproduce_api_example(example_path):
     """
     Testing Reproducing examples/api_example


### PR DESCRIPTION
## Dihedral Range Limit
A requested feature that limit the scan range of individual dihedral angles is implemented.

To use this feature, the `dihedralfile` will have 2 more items in each row defining the dihedral angle, i.e.

```
#contents for the dihedralfile
# i     j     k     j   (range_low)   (range_high)
  1     2     3     4     -120            120
  2     3     4     5      -90            150
```
both lower and upper limits are inclusive.

If low and high ranges are missing for all dihedrals, the range limit mask will be disabled, so it's back compatible with the previous versions.

If some but not all rows have missing low and high ranges, they get default full range [-180, 180].

The range limits are implemented as a "Mask" on the original dihedral grid. In all iterations of torsiondrive wavefront propagations (including the initial one that maps the initial geometries to the nearest grid points), the target dihedral grid is checked. If the target grid lies outside the dihedral range limit, the new constrained optimization will be skipped. In this way, the scan is limited inside the specified range. As a result, if the initial geometries are mapped to grids all outside the range limit, the calculation will end without launching any optimizations.

The output `scan.xyz` and `qdata.txt` files will then only contain data from grid points inside the range limit.

### Examples
An example calculation can be found 
The final 2-D grid is limited to `d1 = -150 ~ 90, d2 = -120 ~ 120`.

Screenshot of running limited range scan:
```
--== Ramachandran Plot of Optimization Status ==--
--== Blue: Optimized, Green: Found Lower, Red: Next ==--
    -165  -120   -75   -30    15    60   105   150
 180                                                 
 150                                                 
 120             ／--＞----------＜--＼              
  90           ／--／--------------＼--＼            
  60         ／--／------------------＼--            
  30       ／--／----------------------\/            
   0     ／--／--------------------------            
 -30   ＜--><----------------------------            
 -60     ＼--＼--------------------------            
 -90       ＼--＼----------------------/\            
-120         ＼--＞------------------＜--            
-150                                                 

```
### Tests updates

The tests setup are updated in the following way:

1. pytest.fixture is used to create temporary directories for running tests. (requires pytest >= 1.9)

2. Some tests requiring large cached example files now will download the example files from a remote repository: https://github.com/lpwgroup/torsiondrive_examples. This will allow the example files to be updated without adding to much to the torsiondrive repo commit history. 

3. A new 2-D test is added to reproduce the `range_limited` example.

3. python 3.5 test and support is dropped.

### Bug fixes

1. The `energy_threshold` option is now stored in `opt_tmp/scanner_settings.json` file to allow checking of consistent settings, to ensure reproducibility.

2. The `--energy_thresh` command line option default value is fixed from 0.0001 to 0.00001 to be consistent with the default value of the `DihedralScanner.__init__()`