### PR TITLE
Update to be compatible with new versions of geomeTRIC and QCEngine

### DIFF
--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -1,11 +1,11 @@
 name: test
 channels:
   - conda-forge
-  - psi4
   - molssi
+  - psi4
 dependencies:
     # Psi test depends
-  - psi4
+  - psi4=1.2.1
   - qcengine
 
     # geomeTRIC base depends

--- a/torsiondrive/qm_engine.py
+++ b/torsiondrive/qm_engine.py
@@ -426,7 +426,7 @@ class EngineQChem(QMEngine):
         self.M.xyzs = [np.array(coords, dtype=float)]
         self.M.build_topology()
 
-    def write_input(self, filename='job.in'):
+    def write_input(self, filename='qc.in'):
         """ Write QChem input using Molecule Class """
         assert hasattr(self, 'qchem_temp'), "self.qchem_temp not set, call load_input() first"
         with open(filename, 'w') as outfile:

--- a/torsiondrive/qm_engine.py
+++ b/torsiondrive/qm_engine.py
@@ -140,12 +140,12 @@ class QMEngine(object):
 
     def load_geomeTRIC_output(self):
         """ Load the optimized geometry and energy into a new molecule object and return """
-        # the name of the file is consistent with the --prefix tdavcft option,
-        # this also requires the input file NOT be named to sth like tdavcft.in
-        # otherwise the output will become tdavcft_optim.xyz
-        if not os.path.isfile('tdavcft.xyz'):
-            raise OSError("geomeTRIC output tdavcft.xyz file not found")
-        m = Molecule('tdavcft.xyz')[-1]
+        # the name of the file is consistent with the --prefix tdrive option,
+        # this also requires the input file NOT be named to sth like tdrive.in
+        # otherwise the output will become tdrive_optim.xyz
+        if not os.path.isfile('tdrive.xyz'):
+            raise OSError("geomeTRIC output tdrive.xyz file not found")
+        m = Molecule('tdrive.xyz')[-1]
         m.qm_energies = [float(m.comms[0].rsplit(maxsplit=1)[-1])]
         return m
 
@@ -332,7 +332,7 @@ class EnginePsi4(QMEngine):
         # step 2
         self.write_input('input.dat')
         # step 3
-        self.run('geometric-optimize --prefix tdavcft --qccnv --reset --epsilon 0.0 --psi4 input.dat constraints.txt > optimize.log', input_files=['input.dat', 'constraints.txt'], output_files=['optimize.log', 'opt.xyz', 'energy.txt'])
+        self.run('geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 --psi4 input.dat constraints.txt > optimize.log', input_files=['input.dat', 'constraints.txt'], output_files=['optimize.log', 'opt.xyz', 'energy.txt'])
 
     def load_native_output(self, filename='output.dat'):
         """ Load the optimized geometry and energy into a new molecule object and return """
@@ -473,7 +473,7 @@ class EngineQChem(QMEngine):
         # step 2
         self.write_input('qc.in')
         # step 3
-        self.run('geometric-optimize --prefix tdavcft --qccnv --reset --epsilon 0.0 --qchem qc.in constraints.txt > optimize.log', input_files=['qc.in', 'constraints.txt'], output_files=['optimize.log', 'opt.xyz', 'energy.txt'])
+        self.run('geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 --qchem qc.in constraints.txt > optimize.log', input_files=['qc.in', 'constraints.txt'], output_files=['optimize.log', 'opt.xyz', 'energy.txt'])
 
     def load_native_output(self, filename='qc.out'):
         """ Load the optimized geometry and energy into a new molecule object and return """
@@ -590,7 +590,7 @@ class EngineTerachem(QMEngine):
         # step 2
         self.write_input()
         # step 3
-        self.run('geometric-optimize --prefix tdavcft --qccnv --reset --epsilon 0.0 run.in constraints.txt > optimize.log', input_files=['run.in', self.tera_geo_file, 'constraints.txt'], output_files=['optimize.log', 'opt.xyz', 'energy.txt'])
+        self.run('geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 run.in constraints.txt > optimize.log', input_files=['run.in', self.tera_geo_file, 'constraints.txt'], output_files=['optimize.log', 'opt.xyz', 'energy.txt'])
 
     def load_native_output(self):
         """ Load the optimized geometry and energy into a new molecule object and return """

--- a/torsiondrive/tests/test_stack.py
+++ b/torsiondrive/tests/test_stack.py
@@ -73,8 +73,8 @@ class Psi4QCEngineEngine(QMEngine):
         """ Load the optimized geometry and energy from self.out_json_dict into a new molecule object and return """
         out_json_dict = self.stored_results.pop(os.getcwd())
         mdict = out_json_dict['final_molecule']
-        #import IPython
-        #IPython.embed()
+        if not mdict:
+            raise RuntimeError("QCEngine failed.\n" + str(out_json_dict))
         m = Molecule()
         m.xyzs = [np.array(mdict['geometry']).reshape(-1, 3) * bohr2ang]
         m.elem = mdict['symbols']

--- a/torsiondrive/tests/test_stack.py
+++ b/torsiondrive/tests/test_stack.py
@@ -44,7 +44,7 @@ class Psi4QCEngineEngine(QMEngine):
             'set': [{'type': 'dihedral', 'indices': [d1, d2, d3, d4], 'value': v} for d1, d2, d3, d4, v in self.dihedral_idx_values]
         }
         qc_schema_input = {
-            "schema_name": "qc_schema_input",
+            "schema_name": "qcschema_input",
             "schema_version": 1,
             "driver": "gradient",
             "model": {
@@ -54,7 +54,7 @@ class Psi4QCEngineEngine(QMEngine):
             "keywords": {}
         }
         in_json_dict = {
-            "schema_name": "qc_schema_optimization_input",
+            "schema_name": "qcschema_optimization_input",
             "schema_version": 1,
             "keywords": {
                 "coordsys": "tric",
@@ -73,6 +73,8 @@ class Psi4QCEngineEngine(QMEngine):
         """ Load the optimized geometry and energy from self.out_json_dict into a new molecule object and return """
         out_json_dict = self.stored_results.pop(os.getcwd())
         mdict = out_json_dict['final_molecule']
+        #import IPython
+        #IPython.embed()
         m = Molecule()
         m.xyzs = [np.array(mdict['geometry']).reshape(-1, 3) * bohr2ang]
         m.elem = mdict['symbols']

--- a/torsiondrive/tests/test_stack_api.py
+++ b/torsiondrive/tests/test_stack_api.py
@@ -82,7 +82,7 @@ class SimpleServer:
             'set': [{'type': 'dihedral', 'indices': list(d), 'value': v} for d, v in zip(self.dihedrals, dihedral_values)]
         }
         qc_schema_input = {
-            "schema_name": "qc_schema_input",
+            "schema_name": "qcschema_input",
             "schema_version": 1,
             "driver": "gradient",
             "model": {
@@ -93,7 +93,7 @@ class SimpleServer:
         }
 
         geometric_input_dict = {
-            "schema_name": "qc_schema_optimization_input",
+            "schema_name": "qcschema_optimization_input",
             "schema_version": 1,
             "keywords": {
                 "coordsys": "tric",


### PR DESCRIPTION
In a later version of geomeTRIC, the `opt.xyz` and `energy.txt` files will be removed. Therefore we now parses the `tdrive.xyz` file that contains the final energy and geometry.

The `QCSchema` was also changed so that the previous `test_stack.py` and `test_stack_api` fails. I found that renaming them from `qc_schema_input` to `qcschema_input` should solve the issue.

However pytest still prints a lot of warnings for QCEngine calling Psi4:
```
  /home/qyd/codes/anaconda3/envs/geometric/lib/python3.6/site-packages/psi4/driver/qcdb/molparse/from_arrays.py:304: DeprecationWarning: elementwise == 
comparison failed; this will raise an error in the future.
    if domain == 'qm' and geom is None or geom == []:
```

Maybe @dgasmith have some ideas on these.