### PR TITLE
Improve range limit, error handling and docs

### DIFF
--- a/torsiondrive/dihedral_scanner.py
+++ b/torsiondrive/dihedral_scanner.py
@@ -247,7 +247,7 @@ class DihedralScanner:
                     if len(self.dihedrals) == 2:
                         print(self.draw_ramachandran_plot())
                     else:
-                        print(self.draw_ascii_image())
+                        print(self.draw_ansi_image())
                 except UnicodeEncodeError:
                     print("Warning: UnicodeEncodeError occured, status map not printed.")
                 last_print_time = current_time
@@ -519,10 +519,10 @@ class DihedralScanner:
     # Status Drawing Utilites
     #----------------------------------
 
-    def draw_ascii_image(self):
-        """ Return a string with ASCII colors showing current running status """
+    def draw_ansi_image(self):
+        """ Return a string with ANSI colors showing current running status """
         if not hasattr(self, 'grid_energies') or not hasattr(self, 'opt_queue'):
-            return "draw_ascii_image failed: grid_energies or opt_queue not available"
+            return "draw_ansi_image failed: grid_energies or opt_queue not available"
         result_str = ""
         count = 0
         running_to_job_ids = set(to_grid_id for m, from_grid_id, to_grid_id in self.opt_queue)
@@ -580,4 +580,3 @@ class DihedralScanner:
         for y in grid_y[::-1]:
             line = '%4d '%y + ''.join(status_symbols[grid_status[(x,y)]] for x in grid_x) + '\n'
             result_str += line
-        return result_str.encode('utf-8')

--- a/torsiondrive/launch.py
+++ b/torsiondrive/launch.py
@@ -53,7 +53,7 @@ def load_dihedralfile(dihedralfile, zero_based_numbering=False):
     dihedral_ranges: list of list of 2 numbers
         dihedral ranges should be either empty (no limit), or two numbers [low, high],
         e.g. [[-120, 120], [-90, 150]]
-        low >= -180, high <= 180, low < high
+        requirements: low >= -180, high <= 360, low < high
     """
     dihedral_idxs = []
     dihedral_ranges = []
@@ -86,7 +86,7 @@ def load_dihedralfile(dihedralfile, zero_based_numbering=False):
     # check all dihedrals valid (>= 0)
     assert all(i >= 0 for d in dihedral_idxs for i in d), f'Dihedral indices {dihedral_idxs} error, all should >= 0'
     # check all ranges valid [-180, 180]
-    assert all(low >= -180 and high <= 180 and low < high for low, high in dihedral_ranges), f'Dihedral ranges {dihedral_ranges} mistaken, range should be within [-180, 180]'
+    assert all(low >= -180 and high <= 360 and low < high for low, high in dihedral_ranges), f'Dihedral ranges {dihedral_ranges} mistaken, range should be within [-180, 180]'
     # check dihedral_idxs and dihedral_ranges have same length
     if dihedral_ranges != []:
         assert len(dihedral_idxs) == len(dihedral_ranges), f'Dihedral ranges {dihedral_ranges} length not consistent with dihedral idxs {dihedral_idxs}'


### PR DESCRIPTION
This PR contains three improvements:

1. The dihedral range limit can now support [-180, 360]. The extended range [180, 360] is solely for the purpose of supporting the dihedral range that cross the boundary, i.e. range limit of [80, 240] means the dihedral angle can be in range [-180, -120] or range [80, 180]. (requested by Mudong)

2. The unicode encoding of special characters in the ramachandran_plot could cause an error, i.e.
```
>> print(self.draw_ramachandran_plot())
UnicodeEncodeError: 'ascii' codec can't encode character '\uff1e' in position 865: ordinal not in range(128)
```
This happened in Mudong's environment but I was not able to reproduce. It may be solved by
```
export PYTHONIOENCODING=utf8
```
I also added an error handling so it will not interrupt the scan when the encoding fails.

3. Several doc strings are improved.