### PR TITLE
Improve failed optimization job handling and update work queue version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
     - os: linux
       python: 3.6
       env: PYTHON_VER=3.6
+    - os: linux
+      python: 3.7
+      env: PYTHON_VER=3.7
 
 before_install:
   # Additional info about the build

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - source activate test
 
     # Build and install package
-  - bash devtools/travis-ci/install-cctools-62.sh
+  - bash devtools/travis-ci/install-cctools.sh
   - python setup.py develop --no-deps
 
     # Print versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 # Run jobs on container-based infrastructure, can be overridden per job
-dist: trusty
+dist: xenial
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 torsiondrive
 ==============================
-[![Travis Build Status](https://travis-ci.org/lpwgroup/torsiondrive.png)](https://travis-ci.org/lpwgroup/torsiondrive)
+[![Travis Build Status](https://travis-ci.org/lpwgroup/torsiondrive.svg?branch=master)](https://travis-ci.org/lpwgroup/torsiondrive)
 [![codecov](https://codecov.io/gh/lpwgroup/torsiondrive/branch/master/graph/badge.svg)](https://codecov.io/gh/lpwgroup/torsiondrive/branch/master)
 
 Dihedral scanner with wavefront propagation

--- a/devtools/travis-ci/install-cctools.sh
+++ b/devtools/travis-ci/install-cctools.sh
@@ -5,10 +5,10 @@ echo "Downloading source."
 version="7.0.10"
 cctools="cctools-$version"
 rm -rf cctools*
-wget https://github.com/lpwgroup/cctools/archive/v$(version).tar.gz
+wget https://github.com/lpwgroup/cctools/archive/v${version}.tar.gz
 echo "Extracting archive."
-tar xzf v$(version).tar.gz
-cd cctools-$(version)
+tar xzf v${version}.tar.gz
+cd cctools-${version}
 
 # Increase all sorts of timeouts.
 sed -i s/"timeout = 5;"/"timeout = 7200;"/g work_queue/src/*.c

--- a/devtools/travis-ci/install-cctools.sh
+++ b/devtools/travis-ci/install-cctools.sh
@@ -2,13 +2,13 @@
 
 # Download latest version from website.
 echo "Downloading source."
-cctools="cctools-6.2.10"
-cctools_src="$cctools-source"
-rm -rf $cctools_src $cctools_src.tar*
-wget http://www3.nd.edu/~ccl/software/files/$cctools_src.tar.gz
+version="7.0.10"
+cctools="cctools-$version"
+rm -rf cctools*
+wget https://github.com/lpwgroup/cctools/archive/v$(version).tar.gz
 echo "Extracting archive."
-tar xzf $cctools_src.tar.gz
-cd $cctools_src
+tar xzf v$(version).tar.gz
+cd cctools-$(version)
 
 # Increase all sorts of timeouts.
 sed -i s/"timeout = 5;"/"timeout = 7200;"/g work_queue/src/*.c

--- a/torsiondrive/dihedral_scanner.py
+++ b/torsiondrive/dihedral_scanner.py
@@ -452,7 +452,7 @@ class DihedralScanner:
                 result_m.build_topology()
                 grid_id = self.get_dihedral_id(result_m, check_grid_id=to_grid_id)
                 if grid_id is None:
-                    print(f"Cached result from {job_folder} is ignored because constrained optimization result is not close enough to grid id {to_grid_id}")
+                    print(f"Cached result from {job_folder} is ignored because optimized geometry is far from grid id {to_grid_id}")
                 else:
                     self.current_finished_job_results.push((result_m, grid_id), priority=job_folder)
                 #self.grid_status[to_grid_id].append((m.xyzs[0], final_geo, final_energy))
@@ -519,7 +519,7 @@ class DihedralScanner:
             # we will check here if the optimized structure has the desired dihedral ids
             grid_id = self.get_dihedral_id(m, check_grid_id=to_grid_id)
             if grid_id is None:
-                print(f"Constrained optimization result at {job_path} is skipped, since it's not enough to grid id {to_grid_id}")
+                print(f"Constrained optimization result at {job_path} is skipped, because final geometry is far from grid id {to_grid_id}")
             else:
                 # each finished job result is a tuple of (m, grid_id)
                 self.current_finished_job_results.push((m, grid_id), priority=job_path)

--- a/torsiondrive/extra_constraints.py
+++ b/torsiondrive/extra_constraints.py
@@ -79,7 +79,7 @@ def make_constraints_dict(constraints_string):
                 raise ValueError(f"Line {line}\nConstraints mode {constraints_mode} is not supported")
     return constraints_dict
 
-def check_conflict_constraits(constraints_dict, dihedral_idxs):
+def check_conflict_constraints(constraints_dict, dihedral_idxs):
     """
     Utility function to check if any extra constraints in constraints_dict is conflict with the scanning dihedrals
     """

--- a/torsiondrive/launch.py
+++ b/torsiondrive/launch.py
@@ -3,7 +3,7 @@
 
 from torsiondrive.dihedral_scanner import DihedralScanner
 from torsiondrive.qm_engine import EnginePsi4, EngineQChem, EngineTerachem
-from torsiondrive.extra_constraints import make_constraints_dict, check_conflict_constraits
+from torsiondrive.extra_constraints import make_constraints_dict, check_conflict_constraints
 from geometric.molecule import Molecule
 
 def load_dihedralfile(dihedralfile, zero_based_numbering=False):
@@ -145,7 +145,7 @@ def main():
         with open(args.constraints) as fin:
             constraints_dict = make_constraints_dict(fin.read())
             # check if there are extra constraints conflict with the specified dihedral angles
-            check_conflict_constraits(constraints_dict, dihedral_idxs)
+            check_conflict_constraints(constraints_dict, dihedral_idxs)
 
     # format grid spacing
     n_grid_spacing = len(args.grid_spacing)

--- a/torsiondrive/td_api.py
+++ b/torsiondrive/td_api.py
@@ -121,7 +121,10 @@ class DihedralScanRepeater(DihedralScanner):
                 result_m.qm_energies = [final_energy]
                 result_m.build_topology()
                 grid_id = self.get_dihedral_id(result_m, check_grid_id=to_grid_id)
-                self.current_finished_job_results.push((result_m, grid_id), priority=job_folder)
+                if grid_id is None:
+                    print(f"Cached result from {job_folder} is ignored because constrained optimization result is not close enough to grid id {to_grid_id}")
+                else:
+                    self.current_finished_job_results.push((result_m, grid_id), priority=job_folder)
             else:
                 # append the job to self.next_jobs, which is the output of torsiondrive-API
                 self.next_jobs[to_grid_id].append(m.xyzs[0].copy())

--- a/torsiondrive/td_api.py
+++ b/torsiondrive/td_api.py
@@ -122,7 +122,7 @@ class DihedralScanRepeater(DihedralScanner):
                 result_m.build_topology()
                 grid_id = self.get_dihedral_id(result_m, check_grid_id=to_grid_id)
                 if grid_id is None:
-                    print(f"Cached result from {job_folder} is ignored because constrained optimization result is not close enough to grid id {to_grid_id}")
+                    print(f"Cached result from {job_folder} is ignored because optimized geometry is far from grid id {to_grid_id}")
                 else:
                     self.current_finished_job_results.push((result_m, grid_id), priority=job_folder)
             else:

--- a/torsiondrive/tests/test_dihedral_scanner.py
+++ b/torsiondrive/tests/test_dihedral_scanner.py
@@ -43,6 +43,7 @@ def test_dihedral_scanner_methods():
     # test methods
     gid = (120, -60)
     assert scanner.get_dihedral_id(m) == gid
+    assert scanner.get_dihedral_id(m, check_grid_id=(120, -90)) == None
     assert set(scanner.grid_neighbors(gid)) == {(90, -60), (150, -60), (120, -90), (120, -30)}
     assert set(scanner.grid_full_neighbors(gid)) == {(90, -90), (90, -30), (150, -90), (150, -30)}
     scanner.push_initial_opt_tasks()

--- a/torsiondrive/tests/test_extra_constraints.py
+++ b/torsiondrive/tests/test_extra_constraints.py
@@ -3,7 +3,7 @@ Unit and regression test for the torsiondrive extra constraints feature
 """
 
 import pytest
-from torsiondrive.extra_constraints import make_constraints_dict, check_conflict_constraits, \
+from torsiondrive.extra_constraints import make_constraints_dict, check_conflict_constraints, \
     build_geometric_constraint_string, build_terachem_constraint_string
 
 
@@ -90,9 +90,9 @@ def test_make_constraints_dict():
     with pytest.raises(AssertionError):
         make_constraints_dict(wrong_constraits_string)
 
-def test_check_conflict_constraits():
+def test_check_conflict_constraints():
     """
-    Test the check_conflict_constraits() function
+    Test the check_conflict_constraints() function
 
     Notes
     -----
@@ -110,20 +110,20 @@ def test_check_conflict_constraits():
     '''
     constraints_dict = make_constraints_dict(constraits_string)
     # empty check
-    check_conflict_constraits(constraints_dict, [])
+    check_conflict_constraints(constraints_dict, [])
     # test valid constraints_dict when not conflicting
     dihedral_idxs = [[1,2,3,4], [2,3,4,5]]
-    check_conflict_constraits(constraints_dict, dihedral_idxs)
+    check_conflict_constraints(constraints_dict, dihedral_idxs)
     # test conflicting
     with pytest.raises(ValueError):
         # dihedral conflict (same as scanning)
-        check_conflict_constraits(constraints_dict, [[0,1,2,3]])
+        check_conflict_constraints(constraints_dict, [[0,1,2,3]])
     with pytest.raises(ValueError):
         # dihedral conflict (share the same center atoms 1, 2)
-        check_conflict_constraits(constraints_dict, [[5,2,1,6]])
+        check_conflict_constraints(constraints_dict, [[5,2,1,6]])
     with pytest.raises(ValueError):
         # xyz conflict
-        check_conflict_constraits(constraints_dict, [[0,1,2,5]])
+        check_conflict_constraints(constraints_dict, [[0,1,2,5]])
 
 def test_build_geometric_constraint_string():
     """

--- a/torsiondrive/tests/test_extra_constraints.py
+++ b/torsiondrive/tests/test_extra_constraints.py
@@ -116,8 +116,11 @@ def test_check_conflict_constraits():
     check_conflict_constraits(constraints_dict, dihedral_idxs)
     # test conflicting
     with pytest.raises(ValueError):
-        # dihedral conflict
+        # dihedral conflict (same as scanning)
         check_conflict_constraits(constraints_dict, [[0,1,2,3]])
+    with pytest.raises(ValueError):
+        # dihedral conflict (share the same center atoms 1, 2)
+        check_conflict_constraits(constraints_dict, [[5,2,1,6]])
     with pytest.raises(ValueError):
         # xyz conflict
         check_conflict_constraits(constraints_dict, [[0,1,2,5]])

--- a/torsiondrive/tests/test_reproduce_examples.py
+++ b/torsiondrive/tests/test_reproduce_examples.py
@@ -18,7 +18,7 @@ def example_path(tmpdir_factory):
     # tmpdir_factory is a pytest built-in fixture that has "session" scope
     tmpdir = tmpdir_factory.mktemp('torsiondrive_test_tmp')
     tmpdir.chdir()
-    example_version = '0.9.5.1'
+    example_version = '0.9.5.2'
     url = f'https://github.com/lpwgroup/torsiondrive_examples/archive/v{example_version}.tar.gz'
     subprocess.run(f'wget -nc -q {url}', shell=True, check=True)
     subprocess.run(f'tar zxf v{example_version}.tar.gz', shell=True, check=True)

--- a/torsiondrive/tests/test_wq_tools.py
+++ b/torsiondrive/tests/test_wq_tools.py
@@ -7,12 +7,17 @@ import os
 import sys
 import subprocess
 
+try:
+    import work_queue
+except:
+    pass
+
 @pytest.mark.skipif("work_queue" not in sys.modules, reason='work_queue not found')
 def test_work_queue():
     from torsiondrive.wq_tools import WorkQueue
     wq = WorkQueue(56789)
     wq.submit('echo test > test.txt', [], ['test.txt'])
-    assert wq.get_queue_status() == (0,0,0,0)
+    assert wq.get_queue_status() == (0,0,0,1)
     # submit a worker
     p = subprocess.Popen("$HOME/opt/cctools/bin/work_queue_worker localhost 56789 -t 1", shell=True)
     for _ in range(10):

--- a/torsiondrive/wq_tools.py
+++ b/torsiondrive/wq_tools.py
@@ -10,7 +10,7 @@ import work_queue
 class WorkQueue:
     def __init__(self, port, name='dihedral'):
         work_queue.set_debug_flag('all')
-        wq = work_queue.WorkQueue(port=port, exclusive=False, shutdown=False)
+        wq = work_queue.WorkQueue(port=port)
         wq.specify_keepalive_interval(8640000)
         wq.specify_name(name)
         self.wq = wq

--- a/torsiondrive/wq_tools.py
+++ b/torsiondrive/wq_tools.py
@@ -65,7 +65,7 @@ class WorkQueue:
         n_running_workers = stats.workers_busy
         n_all_workers = stats.total_workers_joined - stats.total_workers_removed
         n_finished_jobs = stats.total_tasks_complete - self.tasks_failed
-        n_total_jobs = stats.total_tasks_dispatched - self.tasks_failed
+        n_total_jobs = stats.tasks_submitted - self.tasks_failed
         return n_running_workers, n_all_workers, n_finished_jobs, n_total_jobs
 
     def print_queue_status(self, min_time_interval=10, max_time_interval=3600):


### PR DESCRIPTION
This PR address issue #37, after the update, a previous example "extra_constraints" used in regression tests give difference result, so I reran and updated the example in the `torsiondrive_examples` repository.

The `cctools.work_queue` toolkit is updated to the latest master version.
The reason behind this is that the testing environment of `QCEngine` requires `Psi4 1.3`, and it then requires `pcmsolver 1.2.1` which requires `Python >= 3.7`.

The previous cctools installation script downloads and installs `cctools 6.2.10`, which does not support python binding for `Python 3.7`. The support for Python 3.7 is very recently merged into the master branch and there is no release yet from the original cctools repo.

In order to download and install a pinned version, I forked the cctools repo and cut a release at https://github.com/lpwgroup/cctools/releases/tag/v7.0.10 

The packaged source code https://github.com/lpwgroup/cctools/archive/v7.0.10.tar.gz is used in the new `cctools-install.sh` script.

One side effect is that the new version of work_queue prints even more debug information when using `work_queue.set_debug_flag('all')`. We might want to reduce the amount of debug information by removing or changing the debug flag for the `work_queue` package.

One addition improvement in this PR is that the extra dihedral constraints will also be checked that they should not share the same center atom indices with the main scanning dihedrals, for example, if we're scanning dihedral [1,2,3,4], then extra constraints for dihedral [5,3,2,6] will cause an error. This is  based on Lee-Ping's advice that geomeTRIC will have problem with these constraints appearing at the same time.