### PR TITLE
update travis script based on new version of cookiecutter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: python
 
 # Run jobs on container-based infrastructure, can be overridden per job
-dist: xenial
+# dist: xenial
 
 matrix:
   include:
     - os: linux
-      python: 3.6
+      language: generic  # No need to set Python version since its conda
       env: PYTHON_VER=3.6
     - os: linux
-      python: 3.7
+      language: generic
       env: PYTHON_VER=3.7
 
 before_install:
@@ -24,9 +24,11 @@ before_install:
 
 install:
 
-    # Create test environment for package
-  - conda env create -n test python=$PYTHON_VER -f devtools/conda-envs/psi.yaml
-  - source activate test
+  # Create test environment for package
+  - python devtools/scripts/create_conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/psi.yaml
+
+    # Activate the test environment
+  - conda activate test
 
     # Build and install package
   - bash devtools/travis-ci/install-cctools.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - python devtools/scripts/create_conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/psi.yaml
 
     # Activate the test environment
-  - conda activate test
+  - source activate test
 
     # Build and install package
   - bash devtools/travis-ci/install-cctools.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 # Run jobs on container-based infrastructure, can be overridden per job
-# dist: xenial
+dist: xenial
 
 matrix:
   include:

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -8,9 +8,8 @@ dependencies:
   - psi4=1.3
   - qcengine=0.6.1
 
-    # geomeTRIC base depends
-  - numpy
-  - networkx
+    # geomeTRIC
+  - geomeTRIC
 
     # for building cctools.workqueue
   - swig
@@ -19,6 +18,3 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
-
-  - pip:
-    - git+git://github.com/leeping/geomeTRIC#egg=geometric

--- a/devtools/scripts/create_conda_env.py
+++ b/devtools/scripts/create_conda_env.py
@@ -1,0 +1,95 @@
+import argparse
+import os
+import re
+import glob
+import shutil
+import subprocess as sp
+from tempfile import TemporaryDirectory
+from contextlib import contextmanager
+# YAML imports
+try:
+    import yaml  # PyYAML
+    loader = yaml.load
+except ImportError:
+    try:
+        import ruamel_yaml as yaml  # Ruamel YAML
+    except ImportError:
+        try:
+            # Load Ruamel YAML from the base conda environment
+            from importlib import util as import_util
+            CONDA_BIN = os.path.dirname(os.environ['CONDA_EXE'])
+            ruamel_yaml_path = glob.glob(os.path.join(CONDA_BIN, '..',
+                                                      'lib', 'python*.*', 'site-packages',
+                                                      'ruamel_yaml', '__init__.py'))[0]
+            # Based on importlib example, but only needs to load_module since its the whole package, not just
+            # a module
+            spec = import_util.spec_from_file_location('ruamel_yaml', ruamel_yaml_path)
+            yaml = spec.loader.load_module()
+        except (KeyError, ImportError, IndexError):
+            raise ImportError("No YAML parser could be found in this or the conda environment. "
+                              "Could not find PyYAML or Ruamel YAML in the current environment, "
+                              "AND could not find Ruamel YAML in the base conda environment through CONDA_EXE path. " 
+                              "Environment not created!")
+    loader = yaml.YAML(typ="safe").load  # typ="safe" avoids odd typing on output
+
+
+@contextmanager
+def temp_cd():
+    """Temporary CD Helper"""
+    cwd = os.getcwd()
+    with TemporaryDirectory() as td:
+        try:
+            os.chdir(td)
+            yield
+        finally:
+            os.chdir(cwd)
+
+
+# Args
+parser = argparse.ArgumentParser(description='Creates a conda environment from file for a given Python version.')
+parser.add_argument('-n', '--name', type=str,
+                    help='The name of the created Python environment')
+parser.add_argument('-p', '--python', type=str,
+                    help='The version of the created Python environment')
+parser.add_argument('conda_file',
+                    help='The file for the created Python environment')
+
+args = parser.parse_args()
+
+# Open the base file
+with open(args.conda_file, "r") as handle:
+    yaml_script = loader(handle.read())
+
+python_replacement_string = "python {}*".format(args.python)
+
+try:
+    for dep_index, dep_value in enumerate(yaml_script['dependencies']):
+        if re.match('python([ ><=*]+[0-9.*]*)?$', dep_value):  # Match explicitly 'python' and its formats
+            yaml_script['dependencies'].pop(dep_index)
+            break  # Making the assumption there is only one Python entry, also avoids need to enumerate in reverse
+except (KeyError, TypeError):
+    # Case of no dependencies key, or dependencies: None
+    yaml_script['dependencies'] = []
+finally:
+    # Ensure the python version is added in. Even if the code does not need it, we assume the env does
+    yaml_script['dependencies'].insert(0, python_replacement_string)
+
+# Figure out conda path
+if "CONDA_EXE" in os.environ:
+    conda_path = os.environ["CONDA_EXE"]
+else:
+    conda_path = shutil.which("conda")
+if conda_path is None:
+    raise RuntimeError("Could not find a conda binary in CONDA_EXE variable or in executable search path")
+
+print("CONDA ENV NAME  {}".format(args.name))
+print("PYTHON VERSION  {}".format(args.python))
+print("CONDA FILE NAME {}".format(args.conda_file))
+print("CONDA PATH      {}".format(conda_path))
+
+# Write to a temp directory which will always be cleaned up
+with temp_cd():
+    temp_file_name = "temp_script.yaml"
+    with open(temp_file_name, 'w') as f:
+        f.write(yaml.dump(yaml_script))
+    sp.call("{} env create -n {} -f {}".format(conda_path, args.name, temp_file_name), shell=True)

--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -1,6 +1,8 @@
 # Temporarily change directory to $HOME to install software
 pushd .
 cd $HOME
+# Make sure some level of pip is installed
+python -m ensurepip
 
 # Install Miniconda
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
@@ -11,7 +13,6 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     MINICONDA=Miniconda3-latest-MacOSX-x86_64.sh
 else
     MINICONDA=Miniconda3-latest-Linux-x86_64.sh
-    export PYTHON_VER=$TRAVIS_PYTHON_VERSION
 fi
 MINICONDA_HOME=$HOME/miniconda
 MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
@@ -24,11 +25,17 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 
 # Configure miniconda
 export PIP_ARGS="-U"
-export PATH=$MINICONDA_HOME/bin:$PATH
-    
+# New to conda >=4.4
+echo ". $MINICONDA_HOME/etc/profile.d/conda.sh" >> ~/.bashrc  # Source the profile.d file
+echo "conda activate" >> ~/.bashrc  # Activate conda
+source ~/.bashrc  # source file to get new commands
+#export PATH=$MINICONDA_HOME/bin:$PATH  # Old way, should not be needed anymore
+
 conda config --add channels conda-forge
-conda config --set always_yes yes --set changeps1 no
-conda update --q conda
+
+conda config --set always_yes yes
+conda install conda conda-build jinja2 anaconda-client
+conda update --quiet --all
 
 # Restore original directory
 popd


### PR DESCRIPTION
This PR adopts the usage of `devtools/scripts/create_conda_env.py` from the new version of cookiecutter. 

The previous setting have Python=3.6 still updated to Python 3.7 when creating conda environment.

This PR allows creating conda environments for Python 3.6 and Python 3.7 separately.