### PR TITLE
Energy upper limit feature

### DIFF
--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -5,11 +5,11 @@ channels:
   - psi4
 dependencies:
     # Psi test depends
-  - psi4=1.3
-  - qcengine=0.6.1
+  - psi4=1.3.1
+  - qcengine=0.6.4
 
     # geomeTRIC
-  - geomeTRIC
+  - geomeTRIC>=0.9.5
 
     # for building cctools.workqueue
   - swig

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -5,8 +5,8 @@ channels:
   - psi4
 dependencies:
     # Psi test depends
-  - psi4=1.3.1
-  - qcengine=0.6.4
+  - psi4>=1.3.1
+  - qcengine>=0.6.4
 
     # geomeTRIC
   - geomeTRIC>=0.9.5

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,6 @@ setup(
     url='https://github.com/lpwgroup/torsiondrive',
     install_requires=[
         'numpy>=1.11',
-        'geometric'
+        'geometric>=0.9.5'
     ]
 )

--- a/torsiondrive/launch.py
+++ b/torsiondrive/launch.py
@@ -124,7 +124,8 @@ def main():
     parser.add_argument('-e', '--engine', type=str, default="psi4", choices=['qchem', 'psi4', 'terachem'], help='Engine for running scan')
     parser.add_argument('-c', '--constraints', type=str, default=None, help='Provide a constraints file in geomeTRIC format for additional freeze or set constraints (geomeTRIC or TeraChem only)')
     parser.add_argument('--native_opt', action='store_true', default=False, help='Use QM program native constrained optimization algorithm. This will turn off geomeTRIC package.')
-    parser.add_argument('--energy_thresh', type=float, default=0.00001, help='Only activate grid points if the new optimization is <thre> lower than the previous lowest energy (in a.u.).')
+    parser.add_argument('--energy_thresh', type=float, default=1e-5, help='Only activate grid points if the new optimization is <thre> lower than the previous lowest energy (in a.u.).')
+    parser.add_argument('--energy_upper_limit', type=float, default=None, help='Only activate grid points if the new optimization is less than <thre> higher than the global lowest energy (in a.u.).')
     parser.add_argument('--wq_port', type=int, default=None, help='Specify port number to use Work Queue to distribute optimization jobs.')
     parser.add_argument('--zero_based_numbering', action='store_true', help='Use zero_based_numbering in dihedrals file.')
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Print more information while running.')
@@ -164,7 +165,7 @@ def main():
 
     # create DihedralScanner object
     scanner = DihedralScanner(engine, dihedrals=dihedral_idxs, dihedral_ranges=dihedral_ranges, grid_spacing=grid_spacing, init_coords_M=init_coords_M,
-                              energy_decrease_thresh=args.energy_thresh, extra_constraints=constraints_dict, verbose=args.verbose)
+                              energy_decrease_thresh=args.energy_thresh, energy_upper_limit=args.energy_upper_limit, extra_constraints=constraints_dict, verbose=args.verbose)
     # Run the scan!
     scanner.master()
     # After finish, print result

--- a/torsiondrive/qm_engine.py
+++ b/torsiondrive/qm_engine.py
@@ -254,8 +254,8 @@ class EnginePsi4(QMEngine):
         # step 2
         self.write_input('input.dat')
         # step 3
-        cmd = 'geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 --enforce 0.1 --psi4 input.dat constraints.txt > optimize.log'
-        self.run(cmd, input_files=['input.dat', 'constraints.txt'], output_files=['optimize.log', 'tdrive.xyz'])
+        cmd = 'geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 --enforce 0.1 --psi4 input.dat constraints.txt'
+        self.run(cmd, input_files=['input.dat', 'constraints.txt'], output_files=['tdrive.log', 'tdrive.xyz'])
 
     def load_native_output(self, filename='output.dat'):
         """ Load the optimized geometry and energy into a new molecule object and return """
@@ -395,8 +395,8 @@ class EngineQChem(QMEngine):
         # step 2
         self.write_input('qc.in')
         # step 3
-        cmd = 'geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 --enforce 0.1 --qchem qc.in constraints.txt > optimize.log'
-        self.run(cmd, input_files=['qc.in', 'constraints.txt'], output_files=['optimize.log', 'tdrive.xyz'])
+        cmd = 'geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 --enforce 0.1 --qchem qc.in constraints.txt'
+        self.run(cmd, input_files=['qc.in', 'constraints.txt'], output_files=['tdrive.log', 'tdrive.xyz'])
 
     def load_native_output(self, filename='qc.out'):
         """ Load the optimized geometry and energy into a new molecule object and return """
@@ -495,8 +495,8 @@ class EngineTerachem(QMEngine):
         # step 2
         self.write_input()
         # step 3
-        cmd = 'geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 --enforce 0.1 run.in constraints.txt > optimize.log'
-        self.run(cmd, input_files=['run.in', self.tera_geo_file, 'constraints.txt'], output_files=['optimize.log', 'tdrive.xyz'])
+        cmd = 'geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 --enforce 0.1 run.in constraints.txt'
+        self.run(cmd, input_files=['run.in', self.tera_geo_file, 'constraints.txt'], output_files=['tdrive.log', 'tdrive.xyz'])
 
     def load_native_output(self):
         """ Load the optimized geometry and energy into a new molecule object and return """

--- a/torsiondrive/tests/test_dihedral_scanner.py
+++ b/torsiondrive/tests/test_dihedral_scanner.py
@@ -74,3 +74,28 @@ def test_dihedral_scanner_range_masks():
     assert scanner.validate_task(task1) == True
     task2 = (m, (-120, 60), (-120, 90))
     assert scanner.validate_task(task2) == False
+
+def test_dihedral_scanner_energy_upper_limit_filter():
+    """
+    Test dihedral scanner energy_upper_limit as task filters
+    """
+    # setup a scanner
+    m = Molecule()
+    m.elem = ['H'] * 5
+    m.xyzs = [np.array([[0, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 1], [1, 0, 0]], dtype=float)*0.5]
+    m.build_topology()
+    engine = EngineBlank()
+    dihedrals = [[0,1,2,3], [1,2,3,4]]
+    # two ranges are tested, one is normal, one is "split" crossing boundaries
+    dihedral_ranges = [[-120, 120], [150, 240]]
+    scanner = DihedralScanner(engine, dihedrals=dihedrals, grid_spacing=[30, 30], init_coords_M=m, dihedral_ranges=dihedral_ranges, energy_upper_limit=0.001)
+    # check dihedral masks
+    assert scanner.energy_upper_limit == 0.001
+    # test validate_task() function
+    scanner.global_minimum_energy = 0.0
+    m.qm_energies = [0.0]
+    task1 = (m, (-120, 120), (-120, 150))
+    assert scanner.validate_task(task1) == True
+    m.qm_energies = [0.0015]
+    task2 = (m, (-120, 120), (-120, 150))
+    assert scanner.validate_task(task2) == False

--- a/torsiondrive/tests/test_reproduce_examples.py
+++ b/torsiondrive/tests/test_reproduce_examples.py
@@ -18,7 +18,7 @@ def example_path(tmpdir_factory):
     # tmpdir_factory is a pytest built-in fixture that has "session" scope
     tmpdir = tmpdir_factory.mktemp('torsiondrive_test_tmp')
     tmpdir.chdir()
-    example_version = '0.9.5.2'
+    example_version = '0.9.6'
     url = f'https://github.com/lpwgroup/torsiondrive_examples/archive/v{example_version}.tar.gz'
     subprocess.run(f'wget -nc -q {url}', shell=True, check=True)
     subprocess.run(f'tar zxf v{example_version}.tar.gz', shell=True, check=True)
@@ -161,6 +161,33 @@ def test_reproduce_extra_constraints_example(example_path):
     shutil.copy('scan.xyz', 'orig_scan.xyz')
     argv = sys.argv[:]
     sys.argv = 'torsiondrive-launch qc.in dihedrals.txt -g 15 -e qchem -c constraints.txt -v'.split()
+    launch.main()
+    sys.argv = argv
+    assert filecmp.cmp('scan.xyz', 'orig_scan.xyz')
+
+def test_reproduce_energy_upper_limit_example(example_path):
+    """
+    Testing Reproducing examples/extra_constraints
+    """
+    from torsiondrive import launch
+    os.chdir(example_path)
+    os.chdir('energy_upper_limit')
+    # reproduce ring example
+    os.chdir('limit_ring_0.05')
+    subprocess.run('tar zxf opt_tmp.tar.gz', shell=True, check=True)
+    shutil.copy('scan.xyz', 'orig_scan.xyz')
+    argv = sys.argv[:]
+    sys.argv = 'torsiondrive-launch run.in dihedrals.txt -e terachem -g 15 --energy_upper_limit 0.05 -v'.split()
+    launch.main()
+    sys.argv = argv
+    assert filecmp.cmp('scan.xyz', 'orig_scan.xyz')
+    os.chdir('..')
+    # reproduce ring example
+    os.chdir('limit_flexible_0.01')
+    subprocess.run('tar zxf opt_tmp.tar.gz', shell=True, check=True)
+    shutil.copy('scan.xyz', 'orig_scan.xyz')
+    argv = sys.argv[:]
+    sys.argv = 'torsiondrive-launch run.in dihedrals.txt -e terachem -g 10 --energy_upper_limit 0.01 -v'.split()
     launch.main()
     sys.argv = argv
     assert filecmp.cmp('scan.xyz', 'orig_scan.xyz')


### PR DESCRIPTION
This PR implements a new feature in Torsiondrive scan, called `energy_upper_limit`.

### Background
When torsiondrive is scanning dihedrals, it may encounter energy barriers in the PES. Some of the energy barriers are good to be overcome, such as C-C bond rotations in alkanes. However some of the rotations are going to be limited, such as C-C bond rotation in a benzene ring.

To deal with the "not fully rotatable" torsions, we previously implemented a "range limit" feature, that the user can set a limit of the scanning range of individual dihedrals. This allows the above torsions to be scanned without entering "infeasible" region that might cause optimizer to crash.

### Algorithm

The new "energy_upper_limit" feature is designed to solve the issue of "not fully rotatable" torsions in an systematic and automated manner. The idea is that when entering the "infeasible" region of dihedral angles, the QM energy will be very high, and when this happens we could stop the scan from going too far.

The implementation works as "filtering new optimization tasks", similar to the range limit. Before any new QM optimization starts, the energy of its starting geometry will be compared to the "current global minimum", which is the lowest energy seen so far. If the starting energy is higher than the "current_global_minimum + energy_upper_limit", the task will be skipped. When all tasks are finished or skipped, the entire torsiondrive scan finishes.
 
### To be noticed

1. The `energy_upper_limit` does not guarantee that all resulting structures of the torsiondrive are below the threshold. Because only when resulting energies are higher than the threshold will trigger the filter to not starting new optimizations, the first one with the energy too high will be kept in the results. Also, the "current_global_minimum" could become lower during the scan process, making the relative energy of previously accepted results to be higher.

2. If the `energy_upper_limit` value is set, the scan will not be able to overcome energy barriers higher than the `energy_upper_limit`. Therefore when there is a hard barrier splitting the PES into half, you can provide two initial structures locating at each half to be able to cover the PES.

### How to use
It is currently implemented in the command line interface, e.g. `--energy_upper_limit 0.05` will set this option to 0.05, as the upper limit of relative energy to the global minimum, in unit of Hartree.

The JSON API will be updated soon to include this feature, together with a few new features we implemented recently.