### PR TITLE
implement gradients in qdata.txt output

### DIFF
--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -9,7 +9,7 @@ dependencies:
   - qcengine>=0.6.4
 
     # geomeTRIC
-  - geomeTRIC>=0.9.5
+  - geomeTRIC>=0.9.7
 
     # for building cctools.workqueue
   - swig=3

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setup(
     url='https://github.com/lpwgroup/torsiondrive',
     install_requires=[
         'numpy>=1.11',
-        'geometric>=0.9.5'
+        'geometric>=0.9.7'
     ]
 )

--- a/torsiondrive/dihedral_scanner.py
+++ b/torsiondrive/dihedral_scanner.py
@@ -580,7 +580,7 @@ class DihedralScanner:
                 m.qm_grads.append(self.grid_final_gradients[gid])
             m.comms.append("Dihedral %s Energy %.9f" % (str(gid), self.grid_energies[gid]))
         m.write('qdata.txt')
-        print("Final scan energies are written to qdata.txt")
+        print(f"Final scan energies{' and gradients' if writing_gradients else ''} are written to qdata.txt")
         m.write('scan.xyz')
         print("Final scan energies are written to scan.xyz")
 

--- a/torsiondrive/qm_engine.py
+++ b/torsiondrive/qm_engine.py
@@ -259,7 +259,7 @@ class EnginePsi4(QMEngine):
         # step 2
         self.write_input('input.dat')
         # step 3
-        cmd = 'geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 --enforce 0.1 --qdata --psi4 input.dat constraints.txt 2>&1 > optimize.log'
+        cmd = 'geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 --enforce 0.1 --qdata --psi4 input.dat constraints.txt'
         self.run(cmd, input_files=['input.dat', 'constraints.txt'], output_files=['tdrive.log', 'tdrive.xyz', 'qdata.txt'])
 
     def load_native_output(self, filename='output.dat'):
@@ -400,7 +400,7 @@ class EngineQChem(QMEngine):
         # step 2
         self.write_input('qc.in')
         # step 3
-        cmd = 'geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 --enforce 0.1 --qdata --qchem qc.in constraints.txt 2>&1 > optimize.log'
+        cmd = 'geometric-optimize --prefix tdrive --qccnv --reset --epsilon 0.0 --enforce 0.1 --qdata --qchem qc.in constraints.txt'
         self.run(cmd, input_files=['qc.in', 'constraints.txt'], output_files=['tdrive.log', 'tdrive.xyz', 'qdata.txt'])
 
     def load_native_output(self, filename='qc.out'):

--- a/torsiondrive/qm_engine.py
+++ b/torsiondrive/qm_engine.py
@@ -100,7 +100,7 @@ class QMEngine(object):
         if output_files is None:
             output_files = []
         if self.work_queue is None:
-            subprocess.run(cmd, shell=True, check=True, capture_output=True)
+            subprocess.run(cmd, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         else:
             self.work_queue.submit(cmd, input_files, output_files)
 

--- a/torsiondrive/wq_tools.py
+++ b/torsiondrive/wq_tools.py
@@ -9,7 +9,7 @@ import work_queue
 
 class WorkQueue:
     def __init__(self, port, name='dihedral'):
-        work_queue.set_debug_flag('all')
+        # work_queue.set_debug_flag('all')
         wq = work_queue.WorkQueue(port=port)
         wq.specify_keepalive_interval(8640000)
         wq.specify_name(name)


### PR DESCRIPTION
This PR addresses feature request #44 

Previously torsiondrive does not read any gradients information, because it's not needed in the propagations. However, it is realized that when writing the final `qdata.txt` file for ForceBalance, it is convenient to include the gradients.

With the update of `geomeTRIC 0.9.7`, the gradients information can be acquired by specifying `--qdata` and read from the `qdata.txt` file generated by geomeTRIC. Therefore, in the command line interface if the `--native_opt` is *not* specified, geomeTRIC is used as the optimizer and gradients will be written out in the final `qdata.txt` file. For now, when using the native optimizer of QM software, the gradients will not be included.

This implementation is done to be back compatible with previous torsiondrive input/output files. The gradients are "optional", that if they're not available torsiondrive can still run as usual.

When this feature is in use, torsiondrive will need to keep the gradients together with geometry and energy in memory/cache, which basically doubles the memory/disk space usage.