### PR TITLE
Make torsiondrive python 3.12 compatible

### DIFF
--- a/torsiondrive/data/__init__.py
+++ b/torsiondrive/data/__init__.py
@@ -1,0 +1,3 @@
+# Path to this data directory
+import os
+data_dir = os.path.dirname(os.path.abspath(__file__))

--- a/torsiondrive/tests/test_qm_engine.py
+++ b/torsiondrive/tests/test_qm_engine.py
@@ -5,10 +5,10 @@ Test for qm_engine module
 import os
 import subprocess
 import pytest
-from pkg_resources import resource_filename
 import shutil
 import numpy as np
 
+from torsiondrive.data import data_dir
 from torsiondrive.launch import create_engine
 from torsiondrive.qm_engine import QMEngine, EngineBlank, EnginePsi4, EngineQChem, EngineTerachem, EngineOpenMM, EngineGaussian, EnginexTB
 from geometric.molecule import Molecule
@@ -18,7 +18,7 @@ def get_data(relative_path):
     """
     Get the file path to some data in the torsiondrive package.
     """
-    fn = resource_filename("torsiondrive", os.path.join("data", relative_path))
+    fn = os.path.join(data_dir, relative_path)
 
     if not os.path.exists(fn):
         raise ValueError("The file %s can not be found. If you just added it re-install the package."%relative_path)

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
Python 3.12 broke a the vendored versioneer, and also made using `pkg_resources` a bit trickier. This implements the same fixes as the corresponding geomeTRIC pull request (https://github.com/leeping/geomeTRIC/pull/174), although this is much simpler.

As of right now, torsiondrive + ccTools (for `work_queue`) doesn't work with python 3.12, at least when ndcctools is installed via conda/mamba. `ndcctools` is restricted to `<3.12`, but since that is optional for torsiondrive, we can at least make torsiondrive itself compatible with python 3.12.

The `reproduce_api_example` test is failing on my local machine due to files not being exactly the same, although they are very close (just some noise in 15-17 sig figs, ie `2.6457284160064263` vs `2.6457284160064267`). Is this expected?