### PR TITLE
numpy v2, test suite tidying, citation file, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,165 @@
+# Changelog
+
+<!--
+## vX.Y.0 / 2025-MM-DD (Unreleased)
+
+#### Breaking Changes
+
+#### New Features
+ * [\#NN](https://github.com/lpwgroup/torsiondrive/pull/NN) 
+
+#### Enhancements
+
+#### Bug Fixes
+
+#### Misc.
+-->
+
+
+## v1.2.0 / 2025-MM-DD (Unreleased)
+
+#### New Features
+ * [\#74](https://github.com/lpwgroup/torsiondrive/pull/74) Allow TorsionDrive to use xTB's native
+   optimizer (rather than exclusively geomeTRIC) when xTB is the QC engine. @xiki-tempula
+ * [\#76](https://github.com/lpwgroup/torsiondrive/pull/76) Add ASE as a QM engine. @jessicaflowers
+
+#### Enhancements
+ * [\#71](https://github.com/lpwgroup/torsiondrive/pull/71) Allow either "Optimization completed" or
+   "Optimization completed on the basis of negligible forces" to be judged a successful opt. @xiki-tempula
+ * [\#78](https://github.com/lpwgroup/torsiondrive/pull/78) Fixes package for Python 3.12. @bennybp
+ * [\#80](https://github.com/lpwgroup/torsiondrive/pull/80) Adapt package for Numpy v2. Prefer
+   importing `work_queue` from `ndcctools`. Slight adjustments to testing so test suite passes
+   cleanly. Add changelog and citation file. @loriab
+
+#### Bug Fixes
+ * [\#65](https://github.com/lpwgroup/torsiondrive/pull/65) Fix to allow reading Gaussian input with
+   four keywords in the command line. @xiki-tempula
+ * [\#69](https://github.com/lpwgroup/torsiondrive/pull/69) Fix the Gaussian 2D scan to read multiple
+   constraints. @xiki-tempula
+
+
+## v1.1.0 / 2021-09-11
+
+#### New Features
+ * [\#56](https://github.com/lpwgroup/torsiondrive/pull/56) Includes Gaussian as an optimization
+   engine (Josh Horton @JoshHorton)
+
+#### Bug Fixes
+ * [\#61](https://github.com/lpwgroup/torsiondrive/pull/61) Restricting the scan range did not work
+   properly when the range included -180 degrees (David Dotson @dotsdl)
+
+
+## v1.0 / 2019-11-04
+
+#### Enhancements
+ * only for zenodo, no code changes
+
+
+## v0.9.8.1 / 2018-08-07
+
+#### Enhancements
+ * This release contains updated `measure_dihedrals()` function, that provides better checking for
+   linear angles, and runs faster than the original m.measure_dihedrals() function. #49 #52
+   Great contribution from @hyejang
+
+
+## v0.9.8 / 2019-06-19
+
+#### Enhancements
+ * [\#51](https://github.com/lpwgroup/torsiondrive/pull/51) This release mainly contains support for
+   the new OpenMM engine
+ * [\#50](https://github.com/lpwgroup/torsiondrive/pull/50) The cctools installation script is also
+   updated to support the new Swig version 4.
+
+
+## v0.9.7 / 2019-05-30
+
+#### Enhancements
+ * [\#45](https://github.com/lpwgroup/torsiondrive/pull/45) documents published on readthedocs
+ * [\#47](https://github.com/lpwgroup/torsiondrive/pull/47) Refactoring the torsiondrive.tools
+   package including plotting scripts. The components can now be reused in other modules for parsing
+   and visualizing scan.xyz
+ * [\#48](https://github.com/lpwgroup/torsiondrive/pull/48) Gradients information is now provided
+   in the final qdata.txt, then geomeTRIC is used as the optimizer.
+ * [\#46](https://github.com/lpwgroup/torsiondrive/pull/46) CI improvements
+
+
+## v0.9.6 / 2019-04-18
+
+#### Enhancements
+ * This release contains the new "energy upper limit" feature, which allows automated scan of
+   "limited dihedrals", such as C-C-C-C in benzene rings.
+ * The API interface has also been updated, to support the recently developed features that are
+   available in CLI, such as dihedral_ranges, energy_decrease_thresh, energy_upper_limit, extra_constraints.
+ * To support the above features in API, QCFractal running torsiondrive as a service also needs an
+   update, which will be worked on after this release.
+
+
+## v0.9.5 / 2019-03-26
+
+#### Enhancements
+ * Interface with geomeTRIC is updated to 0.9.5
+ * More robust "non-converging constrained optimization" handling behavior (skip instead of accept)
+ * Improved unit test
+ * New version of cctools supporting Python 3.7
+
+
+## v0.9.4 / 2019-02-17
+
+#### Enhancements
+ * [\#31](https://github.com/lpwgroup/torsiondrive/pull/31) This release includes the new feature
+   "Dihedral Range Limit".
+ * Also, tests are improved to use pytest.fixtures, and the large example files are now pulled from
+   a separate repo to avoid increasing space usage of this repo.
+ * Also, the interfaces with geomeTRIC and QCEngine are updated to be compatible with their latest versions.
+
+
+## v0.9.3 / 2019-01-24
+
+#### Bug Fixes
+ * This release contains a bug fix. The bug fixed causes error when using grid spacing of 24 or 40.
+
+
+## v0.9.2 / 2019-01-15
+
+#### Enhancements
+ * This release includes a few latest features including "energy thresholds" and "2-D heatmap plots"
+
+
+## v0.9.1 / 2018-11-01
+
+#### Enhancements
+ * Update tests with new geomeTRIC JSON API
+ * The version number 0.9.1 is intentional to be consistent with geomeTRIC v0.9.1
+
+
+## v0.8.3 / 2018-09-04
+
+#### Enhancements
+ * This release includes adding MANIFEST.in.
+
+
+## v0.8.2 / 2018-08-28
+
+#### Enhancements
+ * This release covers the renaming from crank to torsiondrive, and adopts standard python module naming.
+
+
+## v0.8.1 / 2018-08-04
+
+#### Enhancements
+ * The JSON API for calling geomeTRIC is updated to be compatible with
+   geomeTRIC commit 4876a222a03091fd2323af7c02513676a52c3f31
+
+
+## v0.8.1-beta / 2018-08-04
+
+#### Enhancements
+ * overwrite Examples folder when running tests
+
+
+## v0.8 / 2018-07-30
+
+#### Enhancements
+ * crankAPI switch back to zero-based numbering and updated tests
+

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,57 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: TorsionDrive
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Lee-Ping
+    family-names: Wang
+    affiliation: University of California Davis
+    orcid: 'https://orcid.org/0000-0003-3072-9946'
+  - given-names: Yudong
+    family-names: Qiu
+    orcid: 'https://orcid.org/0000-0003-4345-8356'
+repository-code: 'https://github.com/lpwgroup/torsiondrive'
+abstract: Dihedral scanner with wavefront propagation.
+keywords:
+  - quantum chemistry
+  - molecular geometry optimization
+  - high-throughput computational chemistry
+  - molecular force-field fitting
+license: MIT
+commit: 82bc2b8
+version: 1.1.0
+date-released: '2021-09-11'
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Yudong"
+    given-names: "Qiu"
+    orcid: "https://orcid.org/0000-0003-4345-8356"
+  - family-names: "Smith"
+    given-names: "Daniel G. A."
+    orcid: "https://orcid.org/0000-0001-8626-0900"
+  - family-names: "Stern"
+    given-names: "Chaya D."
+    orcid: "https://orcid.org/0000-0001-6200-3993"
+  - family-names: "Feng"
+    given-names: "Mudong"
+    orcid: "https://orcid.org/0000-0003-1686-0454"
+  - family-names: "Jang"
+    given-names: "Hyesu"
+    orcid: "https://orcid.org/0000-0002-1697-2918"
+  - family-names: "Wang"
+    given-names: "Lee-Ping"
+    orcid: "https://orcid.org/0000-0003-3072-9946"
+  doi: "10.1063/5.0009232"
+  journal: "The Journal of Chemical Physics"
+  month: 6
+  start: 244116
+  title: "Driving torsion scans with wavefront propagation"
+  issue: 24
+  volume: 152
+  year: 2020

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2018 Regents of the University of California
+Copyright (c) 2016-2025 Regents of the University of California
 and the Authors (Yudong Qiu and Lee-Ping Wang).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/torsiondrive/dihedral_scanner.py
+++ b/torsiondrive/dihedral_scanner.py
@@ -673,7 +673,9 @@ class DihedralScanner:
             m.xyzs.append(self.grid_final_geometries[gid])
             if writing_gradients:
                 m.qm_grads.append(self.grid_final_gradients[gid])
-            m.comms.append("Dihedral %s Energy %.9f" % (str(gid), self.grid_energies[gid]))
+            # cast to avoid np v2 test failures merely on "Dihedral (np.int64(15),) Energy ..." vs "Dihedral (15,) Energy ..."
+            printed_gid = tuple(int(x) for x in gid)
+            m.comms.append("Dihedral %s Energy %.9f" % (str(printed_gid), self.grid_energies[gid]))
         m.write('qdata.txt')
         print(f"Final scan energies{' and gradients' if writing_gradients else ''} are written to qdata.txt")
         m.write('scan.xyz')

--- a/torsiondrive/tests/test_reproduce_examples.py
+++ b/torsiondrive/tests/test_reproduce_examples.py
@@ -225,6 +225,13 @@ def test_reproduce_extra_constraints_example(example_path):
     os.chdir(example_path)
     os.chdir('extra_constraints')
     subprocess.run('tar zxf opt_tmp.tar.gz', shell=True, check=True)
+    # reference data is at below and is missing the empty extras_constraints.options
+    # https://github.com/lpwgroup/torsiondrive_examples/blob/master/examples/extra_constraints/constraints.txt
+    #   that is currently written. So we manipulate the ref value to add it.
+    #   Add to constraints.txt to add options.
+    otssj = json.load(open("opt_tmp/scanner_settings.json"))
+    otssj["extra_constraints"]["options"]= []
+    json.dump(otssj, open("opt_tmp/scanner_settings.json", "w"))
     shutil.copy('scan.xyz', 'orig_scan.xyz')
     argv = sys.argv[:]
     with open('run_command') as f:

--- a/torsiondrive/tests/test_reproduce_examples.py
+++ b/torsiondrive/tests/test_reproduce_examples.py
@@ -188,13 +188,34 @@ def test_reproduce_api_example(example_path):
     # test writing current state
     loaded_state = td_api.current_state_json_load(current_state)
     td_api.current_state_json_dump(loaded_state, 'new_current_state.json')
-    assert filecmp.cmp('current_state.json', 'new_current_state.json')
+    # below is failing at trailing decimal places, hence the np compare and qcel compare
+    #   for the irregular lists, if available
+    # assert filecmp.cmp('current_state.json', 'new_current_state.json')
+    cs = json.load(open("current_state.json"))
+    ncs = json.load(open("new_current_state.json"))
+    for k in cs:
+        if k == "elements":
+            assert ncs[k] == cs[k]
+        elif k == "grid_status":
+            try:
+                import qcelemental as qcel
+            except ModuleNotFoundError:
+                pass
+            else:
+                assert qcel.compare_recursive(cs[k], ncs[k], rtol=0, atol=1.e-15)
+        else:
+            assert np.allclose(np.array(ncs[k]), np.array(cs[k]), rtol=0, atol=1.e-15)
     # test calling td_api in command line
     shutil.copy('next_jobs.json', 'orig_next_jobs.json')
     with open('run_command') as f:
         sys.argv = f.read().split()
     td_api.main()
-    assert filecmp.cmp('next_jobs.json', 'orig_next_jobs.json')
+    # again, file compare replaced by np compare
+    # assert filecmp.cmp('next_jobs.json', 'orig_next_jobs.json')
+    onj = json.load(open("orig_next_jobs.json"))
+    nj = json.load(open("next_jobs.json"))
+    for k in orig_next_jobs:
+        assert np.allclose(np.array(nj[k]), np.array(onj[k]), rtol=0, atol=1.e-15)
 
 def test_reproduce_extra_constraints_example(example_path):
     """

--- a/torsiondrive/tests/test_wq_tools.py
+++ b/torsiondrive/tests/test_wq_tools.py
@@ -6,6 +6,7 @@ import pytest
 import os
 import sys
 import subprocess
+import shutil
 
 try:
     from ndcctools import work_queue
@@ -23,7 +24,12 @@ def test_work_queue():
     wq.submit('echo test > test.txt', [], ['test.txt'])
     assert wq.get_queue_status() == (0,0,0,1)
     # submit a worker
-    p = subprocess.Popen("$HOME/opt/cctools/current/bin/work_queue_worker localhost 56789 -t 1", shell=True, stderr=subprocess.DEVNULL)
+    wqw = os.path.expandvars("$HOME/opt/cctools/current/bin/work_queue_worker")  # existing hard-coded
+    if not os.path.isfile(wqw):
+        wqw = shutil.which("work_queue_worker")
+    if not wqw:
+        assert 0, "work_queue_worker cannot be found. please place in PATH"
+    p = subprocess.Popen(f"{wqw} localhost 56789 -t 1", shell=True, stderr=subprocess.DEVNULL)
     for _ in range(10):
         path = wq.check_finished_task_path()
         if path is not None:

--- a/torsiondrive/tests/test_wq_tools.py
+++ b/torsiondrive/tests/test_wq_tools.py
@@ -16,7 +16,7 @@ except ModuleNotFoundError:
         pass
 
 
-@pytest.mark.skipif("work_queue" not in sys.modules, reason='work_queue not found')
+@pytest.mark.skipif(("work_queue" not in sys.modules) and ("ndcctools.work_queue" not in sys.modules), reason='work_queue not found')
 def test_work_queue():
     from torsiondrive.wq_tools import WorkQueue
     wq = WorkQueue(56789)

--- a/torsiondrive/tests/test_wq_tools.py
+++ b/torsiondrive/tests/test_wq_tools.py
@@ -8,9 +8,13 @@ import sys
 import subprocess
 
 try:
-    import work_queue
-except:
-    pass
+    from ndcctools import work_queue
+except ModuleNotFoundError:
+    try:
+        import work_queue
+    except:
+        pass
+
 
 @pytest.mark.skipif("work_queue" not in sys.modules, reason='work_queue not found')
 def test_work_queue():

--- a/torsiondrive/wq_tools.py
+++ b/torsiondrive/wq_tools.py
@@ -4,7 +4,10 @@ import os
 import sys
 import time
 
-import work_queue
+try:
+    from ndcctools import work_queue
+except ModuleNotFoundError:
+    import work_queue
 
 
 class WorkQueue:


### PR DESCRIPTION
With this PR, in a Python 3.13 and Numpy 2.2 and Psi4 master env, the test suite is clean. Basic summary is there's a lot of data at repo `GH:lpwgroup/torsiondrive_examples`. One is supposed to copy everything, edit it, and make a new branch to serve as ref to a new release here. But the changes are so tiny -- `np.int` vs. `int`, 16th decimal differences, an empty list, etc.,  -- that I think that procedure would look like churn. So this PR is light edits in-place to fix all the tests.

* This fixes all the reproduce examples tests failing b/c the type was written into the file, presumably because of numpy v2.
* Fixes the api_example test Ben mentioned in #78 by moving from file to array compare
* Modernizes the import statement for work_queue
* Generalizes the work_queue test so it could run on any computer
* Fixes the `extra_constraints` test  now that an extra field name is printed

```
===== 63 passed, 13 warnings in 580.83s (0:09:40) =====
```
